### PR TITLE
Fix/get template info

### DIFF
--- a/autograder/builder/template_library/library.py
+++ b/autograder/builder/template_library/library.py
@@ -7,7 +7,7 @@ from autograder.builder.models.template import Template
 
 class TemplateLibrary:
     @staticmethod
-    def get_template(template_name: str, custom_template_content: str = None):
+    def get_template(template_name: str, custom_template_content: str = None, clean=False):
         if template_name == "custom":
             if not custom_template_content:
                 raise ValueError("Custom template content must be provided for 'custom' template type.")
@@ -15,16 +15,16 @@ class TemplateLibrary:
 
         if template_name == "web dev":
             from autograder.builder.template_library.templates.web_dev import WebDevTemplate
-            return WebDevTemplate()
+            return WebDevTemplate(clean)
         if template_name == "api":
             from autograder.builder.template_library.templates.api_testing import ApiTestingTemplate
-            return ApiTestingTemplate()
+            return ApiTestingTemplate(clean)
         if template_name == "essay":
             from autograder.builder.template_library.templates.essay_grader import EssayGraderTemplate
-            return EssayGraderTemplate()
-        if template_name == "I/O":
+            return EssayGraderTemplate(clean)
+        if template_name == "IO":
             from autograder.builder.template_library.templates.input_output import InputOutputTemplate
-            return InputOutputTemplate()
+            return InputOutputTemplate(clean)
         else:
             raise ValueError(f"Template '{template_name}' not found.")
 
@@ -56,3 +56,27 @@ class TemplateLibrary:
                 return obj()
 
         raise ImportError(f"No class inheriting from 'Template' found in {file_path}")
+    
+
+    @staticmethod
+    def get_template_info(template_name: str):
+        """Gets all the details of a template.
+        param template_name: The name of the template to retrieve.
+        return: A dictionary with all the template details.
+        example:
+        {
+            "name": "I/O",
+            "description": "Template for testing input/output functions.",
+            "tests": [
+                {
+                    "name": "test_function_1",
+                    "description": "Tests function 1 with various inputs.",
+                    "parameters": {
+                        "input1": "Description of input1",
+                        "input2": "Description of input2"
+                    },
+
+                }, 
+                ...
+        """
+        return TemplateLibrary.get_template(template_name, clean=True)

--- a/autograder/builder/template_library/templates/api_testing.py
+++ b/autograder/builder/template_library/templates/api_testing.py
@@ -163,17 +163,22 @@ class ApiTestingTemplate(Template):
     def execution_helper(self):
         return self.executor
 
-    def __init__(self):
-        self.executor = SandboxExecutor.start()
+    def __init__(self, clean=False):
+        if not clean:
+            # Prepare the environment by running setup commands
+            self.executor = SandboxExecutor.start()
+            self._setup_environment()
+        else:
+            self.executor = None
+    
         self.logger = logging.getLogger(__name__)
-
-        # Prepare the environment by running setup commands
-        self._setup_environment()
 
         self.tests = {
             "health_check": HealthCheckTest(self.executor),
             "check_response_json": CheckResponseJsonTest(self.executor),
         }
+
+
 
     def _setup_environment(self):
         """Runs initial setup commands like installing dependencies and starting the server."""

--- a/autograder/builder/template_library/templates/input_output.py
+++ b/autograder/builder/template_library/templates/input_output.py
@@ -112,9 +112,14 @@ class InputOutputTemplate(Template):
     def execution_helper(self):
         return self.executor
 
-    def __init__(self):
-        self.executor = SandboxExecutor.start()
-        self._setup_environment()
+    def __init__(self, clean=False):
+        
+        if not clean:
+            # Prepare the environment by running setup commands
+            self.executor = SandboxExecutor.start()
+            self._setup_environment()
+        else:
+            self.executor = None
         self.tests = {
             "expect_output": ExpectOutputTest(self.executor),
         }

--- a/autograder/context.py
+++ b/autograder/context.py
@@ -17,7 +17,7 @@ class RequestContext:
             cls._instance.request = None
         return cls._instance
 
-    def set_request(self, autograder_request: AutograderRequest):
+    def set_request(self, autograder_request: AutograderRequest | None):
         """Sets the active autograder request for the current session."""
         self.request = autograder_request
 

--- a/connectors/adapters/api/api_adapter.py
+++ b/connectors/adapters/api/api_adapter.py
@@ -9,7 +9,7 @@ import json
 from connectors.port import Port
 import logging
 from autograder.builder.template_library.library import TemplateLibrary
-
+from autograder.context import request_context
 
 class ApiAdapter(Port):
 
@@ -106,8 +106,11 @@ class ApiAdapter(Port):
         including its name, description, and full details for each test function
         (name, description, parameters, and source code).
         """
+
+        request_context.set_request(AutograderRequest.build_empty_request())
+        print("REQUEST_CONTEXT:", request_context.get_request())
         # 1. Retrieve an instance of the template from the library
-        template_instance = TemplateLibrary.get_template(template_name)
+        template_instance = TemplateLibrary.get_template_info(template_name)
         if not template_instance:
             raise ValueError(f"Template '{template_name}' not found.")
 

--- a/connectors/models/autograder_request.py
+++ b/connectors/models/autograder_request.py
@@ -27,3 +27,12 @@ class AutograderRequest:
         stri += f"Student name: {self.student_name}\n"
         stri += f"Feedback mode: {self.feedback_mode}\n"
         return stri
+
+    @classmethod
+    def build_empty_request(cls):
+        return cls(
+            submission_files={},
+            assignment_config=AssignmentConfig(criteria={}, feedback={}, setup={}, template=""),
+            student_name="",
+            include_feedback=False
+        )


### PR DESCRIPTION
This pull request introduces support for retrieving template details in a "clean" mode that omits environment setup, and refactors template instantiation to accept a `clean` parameter. It also adds a new API method for fetching template information, ensures context setup for API calls, and improves type safety for request handling.

### Template instantiation and "clean" mode support
* Refactored `TemplateLibrary.get_template` and all template constructors (`WebDevTemplate`, `ApiTestingTemplate`, `EssayGraderTemplate`, `InputOutputTemplate`) to accept a `clean` parameter, allowing for instantiation without environment setup. [[1]](diffhunk://#diff-93dced7a2fc4869636616b1215bac7bb5e0ddcc38b70ef27bc16ffd9f208489fL10-R27) [[2]](diffhunk://#diff-b45d3742fbab73dd354c93b28edb5cd3ee1397346406791753a53c108e6e065fL166-R182) [[3]](diffhunk://#diff-2ede9d4309b9c3f5f7853c6856975703c0356eba6493784c64438f88145528f0L115-R122)
* Added `TemplateLibrary.get_template_info` to retrieve template details in clean mode, returning a dictionary of template metadata.

### API adapter improvements
* Updated `ApiAdapter.get_template_info` to use the new `get_template_info` method and set up the request context with an empty autograder request for template info queries. [[1]](diffhunk://#diff-f7993acb06b683602ce94ca5b949fb0021c8963ff44ba6d6625a187ae9404f76R109-R113) [[2]](diffhunk://#diff-f7993acb06b683602ce94ca5b949fb0021c8963ff44ba6d6625a187ae9404f76L12-R12)
* Added `AutograderRequest.build_empty_request` for generating a default, empty request object.

### Type safety and context management
* Improved the signature of `Context.set_request` to accept `AutograderRequest | None`, enhancing type safety.