### PR TITLE
82 allow filtering on template api

### DIFF
--- a/connectors/adapters/api/api_entrypoint.py
+++ b/connectors/adapters/api/api_entrypoint.py
@@ -114,16 +114,15 @@ async def get_template_info(
 
         # Return full details of a specific test
         if test_name:
-            matching_test = None
-            for t in template.get("tests", []):
-                if t["name"] == test_name:
-                    matching_test = t
-                    break
+            matching_test = next(
+                (t for t in template.get("tests", []) if t["name"] == test_name),
+                None
+            )
             if not matching_test:
                 raise ValueError(f"Test '{test_name}' not found in template '{template_name}'")
             return matching_test
 
-        # Return only template details 
+        # Return only template details
         if details_level == "summary":
             return {
                 "template_name": template.get("template_name"),

--- a/connectors/adapters/api/api_entrypoint.py
+++ b/connectors/adapters/api/api_entrypoint.py
@@ -106,14 +106,14 @@ async def get_template_info(
         adapter = ApiAdapter()
         template = adapter.get_template_info(template_name.replace("_", " "))
 
-        # 1 Return only template details
+        # 1. Return only template details
         if details:
             return {
                 "template_name": template["template_name"],
                 "template_description": template["template_description"]
             }
 
-        # 2 Return template details and test names
+        # 2. Return template details and test names
         if summary:
             return {
                 "template_name": template["template_name"],
@@ -121,7 +121,7 @@ async def get_template_info(
                 "test_names": [t["name"] for t in template.get("tests", [])]
             }
 
-        # 3 Return full template
+        # 3. Return full template
         return template
 
     except ValueError as e:


### PR DESCRIPTION
I just finished testing and implementing all the suggested filters.
I also considered adding new ones, but I believe the filters I implemented cover all the requirements.
For the final implementation, I used the following approach:

```python
if test_name:
    # Get the first matching test, stop iterating after the first match
    matching_test = next(
        (t for t in template.get("tests", []) if t["name"] == test_name),
        None
    )
    if not matching_test:
        raise ValueError(f"Test '{test_name}' not found in template '{template_name}'")
    return matching_test
```