### PR TITLE
97 allow printing test object

### DIFF
--- a/autograder/builder/models/criteria_tree.py
+++ b/autograder/builder/models/criteria_tree.py
@@ -180,6 +180,11 @@ class Criteria:
                 if isinstance(result, TestResult):
                     params_str = f" (Parameters: {result.parameters})" if result.parameters else ""
                     print(f"{prefix}  - 📝 {result.test_name}{params_str} -> Score: {result.score}")
+
+                elif isinstance(result, Test):
+                    print(f"{prefix} - 🧪 {result.name} (file: {result.file})")
+                    for call in result.calls:
+                        print(f"{prefix}    - Parameters: {call.args}")
                 else:
                     # Fallback for unexpected types
                     print(f"{prefix}  - ? Unexpected item in tests list: {result}")

--- a/autograder/builder/models/criteria_tree.py
+++ b/autograder/builder/models/criteria_tree.py
@@ -176,6 +176,8 @@ class Criteria:
 
         if subject.tests is not None:
             # In a pre-executed tree, subject.tests contains TestResult objects
+
+            # In the regular tree, subject.tests contains "Test" objects
             for result in subject.tests:
                 if isinstance(result, TestResult):
                     params_str = f" (Parameters: {result.parameters})" if result.parameters else ""
@@ -183,6 +185,7 @@ class Criteria:
 
                 elif isinstance(result, Test):
                     print(f"{prefix} - 🧪 {result.name} (file: {result.file})")
+                    """Added the symbol identificator to match the previous formatting"""
                     for call in result.calls:
                         print(f"{prefix}    - Parameters: {call.args}")
                 else:


### PR DESCRIPTION
Finished adding the feature of printing to "Test" objects. By referencing the ``Test`` class, now the ``criteria_tree`` file correctly prints the parameters of the object by an "elif" statement.