### PR TITLE
98 problem when applying penalty

### DIFF
--- a/autograder/core/grading/grader.py
+++ b/autograder/core/grading/grader.py
@@ -35,16 +35,19 @@ class Grader:
         ## CHANGED: Coalesce None to 0.0 to signify that an empty category contributes nothing to the score.
         base_score = self._grade_subject_or_category(self.criteria.base, submission_files, self.base_results) or 0.0
         bonus_score = self._grade_subject_or_category(self.criteria.bonus, submission_files, self.bonus_results) or 0.0
-        penalty_points = self._calculate_penalty_points(self.criteria.penalty, submission_files,
+        penalty_percentage = self._calculate_penalty_points(self.criteria.penalty, submission_files,
                                                         self.penalty_results) or 0.0
 
         # Step 3: Apply the final scoring logic
-        final_score = self._calculate_final_score(base_score, bonus_score, penalty_points)
+        final_score = self._calculate_final_score(base_score, bonus_score, penalty_percentage)
+
+        penalty_weight = self.criteria.penalty.max_score
+        penalty_points_to_subtract = (penalty_percentage / 100) * penalty_weight
 
         print("\n--- GRADING COMPLETE ---")
         print(f"Aggregated Base Score: {base_score:.2f}")
         print(f"Aggregated Bonus Score: {bonus_score:.2f}")
-        print(f"Total Penalty Points to Subtract: {penalty_points:.2f}")
+        print(f"Total Penalty Points to Subtract: {penalty_points_to_subtract:.2f}")
         print("-" * 25)
         print(f"Final Calculated Score: {final_score:.2f}")
         print("-" * 25)

--- a/autograder/core/grading/grader.py
+++ b/autograder/core/grading/grader.py
@@ -37,10 +37,12 @@ class Grader:
         bonus_score = self._grade_subject_or_category(self.criteria.bonus, submission_files, self.bonus_results) or 0.0
         penalty_percentage = self._calculate_penalty_points(self.criteria.penalty, submission_files,
                                                         self.penalty_results) or 0.0
+        ## CHANGED: Switched the name of the variable "penalty_points" to "penalty_percentage" for further calcu 
 
         # Step 3: Apply the final scoring logic
         final_score = self._calculate_final_score(base_score, bonus_score, penalty_percentage)
 
+        ## ADDED: Added calculations to the actual penalty points for accurate description
         penalty_weight = self.criteria.penalty.max_score
         penalty_points_to_subtract = (penalty_percentage / 100) * penalty_weight
 


### PR DESCRIPTION
After researching the causes of the problem in the ``grader.py`` file, I noticed something about the logging of the penalty points related to how one of the variables were being accessed and used. The variable ``penalty_points`` is a percentage value, but it was used in a label that prints the amount of points that should be subtracted from the total. So, I changed the name of the variable and added the calculations below (that also were present in  the ``calculate_final_score`` function):
 ```python
## ADDED: Added calculations to the actual penalty points for accurate description
penalty_weight = self.criteria.penalty.max_score
penalty_points_to_subtract = (penalty_percentage / 100) * penalty_weight
``` 
Now, the variable is being properly evaluated for the label of ``Total Penalty Points to Substract``. I'm pretty sure that this was the root cause of the problem, since all the calculations made in the code are correct. However, I still wasn't able to send a grading request to verify the changes, so please let me know if there's anything that needs to be changed.