### PR TITLE
allow direct tests

### DIFF
--- a/autograder/builder/tree_builder.py
+++ b/autograder/builder/tree_builder.py
@@ -23,6 +23,10 @@ class CriteriaTree:
                 if "weight" in category_data:
                     category.max_score = category_data.get("weight", 100)
 
+                # Validate that category doesn't have both subjects and tests
+                if "subjects" in category_data and "tests" in category_data:
+                    raise ValueError(f"Config error: Category '{category_name}' cannot have both 'tests' and 'subjects'.")
+
                 if "subjects" in category_data:
                     subjects = [
                         CriteriaTree._parse_and_execute_subject(s_name, s_data, template, submission_files)
@@ -31,6 +35,14 @@ class CriteriaTree:
                     CriteriaTree._balance_subject_weights(subjects)
                     for subject in subjects:
                         category.add_subject(subject)
+                elif "tests" in category_data:
+                    # Handle tests directly at category level
+                    parsed_tests = CriteriaTree._parse_tests(category_data["tests"])
+                    executed_tests = []
+                    for test in parsed_tests:
+                        test_results = test.get_result(template, submission_files, category_name)
+                        executed_tests.extend(test_results)
+                    category.tests = executed_tests
         return criteria
 
     @staticmethod
@@ -48,6 +60,10 @@ class CriteriaTree:
                 if "weight" in category_data:
                     category.max_score = category_data.get("weight", 100)
 
+                # Validate that category doesn't have both subjects and tests
+                if "subjects" in category_data and "tests" in category_data:
+                    raise ValueError(f"Config error: Category '{category_name}' cannot have both 'tests' and 'subjects'.")
+
                 if "subjects" in category_data:
                     subjects = [
                         CriteriaTree._parse_subject(s_name, s_data)
@@ -56,6 +72,9 @@ class CriteriaTree:
                     CriteriaTree._balance_subject_weights(subjects)
                     for subject in subjects:
                         category.add_subject(subject)
+                elif "tests" in category_data:
+                    # Handle tests directly at category level
+                    category.tests = CriteriaTree._parse_tests(category_data["tests"])
         return criteria
 
     @staticmethod


### PR DESCRIPTION
This pull request updates the autograder's criteria tree model and builder logic to support categories that can contain either a list of tests or a dictionary of subjects (but not both), and improves validation, printing, and tree-building to handle this new structure. The changes enforce mutual exclusivity between subjects and tests in a category, update printing methods to display both, and add error handling for misconfigured categories.

**Model and Data Structure Changes:**

* Modified the `TestCategory` class to allow a category to contain either a list of `tests` or a dictionary of `subjects`, but not both. The constructor and `add_subject` method were updated to support this, and the `__repr__` method now reflects whether the category contains tests or subjects.

**Validation and Error Handling:**

* Added validation in both `build_pre_executed_tree` and `build_non_executed_tree` to raise a `ValueError` if a category is configured with both `subjects` and `tests`, ensuring configuration correctness. [[1]](diffhunk://#diff-16ec268e017bfbbfc7257940083e1fe84bfdfb4e4e96305ec2bd6422250610a8R26-R29) [[2]](diffhunk://#diff-16ec268e017bfbbfc7257940083e1fe84bfdfb4e4e96305ec2bd6422250610a8R63-R66)

**Tree Building Logic:**

* Updated tree-building functions to handle categories with direct tests: in `build_pre_executed_tree`, tests are parsed and executed, and in `build_non_executed_tree`, tests are parsed and assigned to the category. [[1]](diffhunk://#diff-16ec268e017bfbbfc7257940083e1fe84bfdfb4e4e96305ec2bd6422250610a8R38-R45) [[2]](diffhunk://#diff-16ec268e017bfbbfc7257940083e1fe84bfdfb4e4e96305ec2bd6422250610a8R75-R77)

**Printing and Output Improvements:**

* Enhanced the printing methods (`print_tree` and `print_pre_executed_tree`) to correctly display categories with either subjects or tests, including detailed output for tests and their results. [[1]](diffhunk://#diff-288fcb759d68aebd6b2f1a8d1287805c401c5562ebe2732da7091e16a21b79a9L133-R155) [[2]](diffhunk://#diff-288fcb759d68aebd6b2f1a8d1287805c401c5562ebe2732da7091e16a21b79a9L162-R195)