### PR TITLE
Fixing API errors

### DIFF
--- a/autograder/autograder_facade.py
+++ b/autograder/autograder_facade.py
@@ -97,7 +97,7 @@ class Autograder:
             error_message = f"An unexpected error occurred during the grading process: {str(e)}"
             logger.error(error_message)
             logger.exception("Full exception traceback:")
-            return AutograderResponse(status="fail", final_score=0.0, feedback=error_message)
+            return AutograderResponse(status="fail", final_score=0.0, feedback=error_message, test_report=[])
 
     @staticmethod
     def _pre_flight_step():

--- a/autograder/core/models/autograder_response.py
+++ b/autograder/core/models/autograder_response.py
@@ -13,7 +13,7 @@ class AutograderResponse(BaseModel):
     status: str
     final_score: float = 0.0
     feedback: str = ""
-    test_report: Optional[List[TestResult]] = Field(default=None)
+    test_report: List[TestResult] = Field(default_factory=list)
 
     def __repr__(self) -> str:
         feedback_size = len(self.feedback) if self.feedback else 0

--- a/connectors/adapters/api/api_adapter.py
+++ b/connectors/adapters/api/api_adapter.py
@@ -22,12 +22,13 @@ class ApiAdapter(Port):
             raise Exception("No autograder response available. Please run the autograder first.")
 
         # Prepare the API response
+        test_report = self.autograder_response.test_report
         response = {
-            "server_status": "Sever connection happened successfully",
+            "server_status": "Server connection happened successfully",
             "autograding_status": self.autograder_response.status,
             "final_score": self.autograder_response.final_score,
             "feedback": self.autograder_response.feedback,
-            "test_report": [test_result.to_dict() for test_result in self.autograder_response.test_report],
+            "test_report": [test_result.to_dict() for test_result in test_report] if test_report else [],
         }
 
         return response

--- a/connectors/adapters/api/api_entrypoint.py
+++ b/connectors/adapters/api/api_entrypoint.py
@@ -96,16 +96,16 @@ async def grade_submission_endpoint(
 
     except ValueError as e:
         logging.error(f"Validation error: {e}")
-        raise HTTPException(status_code=400, detail=f"Validation Error: {e}")
+        raise HTTPException(status_code=400, detail="Validation Error")
     except json.JSONDecodeError as e:
         logging.error(f"JSON parsing error: {e}")
-        raise HTTPException(status_code=400, detail=f"Invalid JSON format: {e}")
+        raise HTTPException(status_code=400, detail="Invalid JSON format")
     except FileNotFoundError as e:
         logging.error(f"File not found: {e}")
-        raise HTTPException(status_code=404, detail=f"File not found: {e}")
+        raise HTTPException(status_code=404, detail="File not found")
     except Exception as e:
         logging.exception(f"Internal Server Error: {e}")
-        raise HTTPException(status_code=500, detail=f"Internal Server Error: {e}")
+        raise HTTPException(status_code=500, detail="Internal Server Error")
 
 @app.get("/templates/{template_name}")
 async def get_template_info(

--- a/connectors/adapters/api/api_entrypoint.py
+++ b/connectors/adapters/api/api_entrypoint.py
@@ -6,7 +6,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional
 from connectors.models.assignment_config import AssignmentConfig
 import uvicorn
-import json
 
 from connectors.adapters.api.api_adapter import ApiAdapter
 # Initialize the FastAPI app
@@ -97,9 +96,6 @@ async def grade_submission_endpoint(
     except ValueError as e:
         logging.error(f"Validation error: {e}")
         raise HTTPException(status_code=400, detail="Validation Error")
-    except json.JSONDecodeError as e:
-        logging.error(f"JSON parsing error: {e}")
-        raise HTTPException(status_code=400, detail="Invalid JSON format")
     except FileNotFoundError as e:
         logging.error(f"File not found: {e}")
         raise HTTPException(status_code=404, detail="File not found")

--- a/connectors/adapters/api/api_entrypoint.py
+++ b/connectors/adapters/api/api_entrypoint.py
@@ -95,13 +95,13 @@ async def grade_submission_endpoint(
 
     except ValueError as e:
         logging.error(f"Validation error: {e}")
-        raise HTTPException(status_code=400, detail="Validation Error")
+        raise HTTPException(status_code=400, detail="Invalid request. Please check your input parameters.")
     except FileNotFoundError as e:
         logging.error(f"File not found: {e}")
-        raise HTTPException(status_code=404, detail="File not found")
+        raise HTTPException(status_code=404, detail="Required file not found.")
     except Exception as e:
-        logging.exception(f"Internal Server Error: {e}")
-        raise HTTPException(status_code=500, detail="Internal Server Error")
+        logging.exception(f"Unexpected error in grade_submission: {e}")
+        raise HTTPException(status_code=500, detail="An internal error occurred while processing your submission.")
 
 @app.get("/templates/{template_name}")
 async def get_template_info(
@@ -148,9 +148,11 @@ async def get_template_info(
         return template
 
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        logging.error(f"Template not found: {e}")
+        raise HTTPException(status_code=404, detail="Template or test not found.")
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal Server Error: {e}")
+        logging.exception(f"Error retrieving template info: {e}")
+        raise HTTPException(status_code=500, detail="An error occurred while retrieving template information.")
 
 @app.get("/health")
 def health_check():

--- a/connectors/adapters/api/api_entrypoint.py
+++ b/connectors/adapters/api/api_entrypoint.py
@@ -6,6 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional
 from connectors.models.assignment_config import AssignmentConfig
 import uvicorn
+import json
 
 from connectors.adapters.api.api_adapter import ApiAdapter
 # Initialize the FastAPI app
@@ -93,7 +94,17 @@ async def grade_submission_endpoint(
         result = adapter.export_results()
         return result
 
+    except ValueError as e:
+        logging.error(f"Validation error: {e}")
+        raise HTTPException(status_code=400, detail=f"Validation Error: {e}")
+    except json.JSONDecodeError as e:
+        logging.error(f"JSON parsing error: {e}")
+        raise HTTPException(status_code=400, detail=f"Invalid JSON format: {e}")
+    except FileNotFoundError as e:
+        logging.error(f"File not found: {e}")
+        raise HTTPException(status_code=404, detail=f"File not found: {e}")
     except Exception as e:
+        logging.exception(f"Internal Server Error: {e}")
         raise HTTPException(status_code=500, detail=f"Internal Server Error: {e}")
 
 @app.get("/templates/{template_name}")


### PR DESCRIPTION
I’ve just implemented the fix for the API error and tested it locally.
This update improves the endpoint by adding explicit handling for the most common failure scenarios. The following exceptions are now properly logged and mapped to meaningful HTTP responses:
```python
 except ValueError as e:
        logging.error(f"Validation error: {e}")
        raise HTTPException(status_code=400, detail=f"Validation Error: {e}")
    except json.JSONDecodeError as e:
        logging.error(f"JSON parsing error: {e}")
        raise HTTPException(status_code=400, detail=f"Invalid JSON format: {e}")
    except FileNotFoundError as e:
        logging.error(f"File not found: {e}")
        raise HTTPException(status_code=404, detail=f"File not found: {e}")
    except Exception as e:
        logging.exception(f"Internal Server Error: {e}")
        raise HTTPException(status_code=500, detail=f"Internal Server Error: {e}")
```
Let me know if you think there’s another scenario I should handle.