### PR TITLE
135 stop making OpenAI and redis credentials required in the autograderrequest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,4 @@ runs:
     TEMPLATE_PRESET: ${{ inputs.template_preset }}
     FEEDBACK_TYPE: ${{ inputs.feedback-type }}
     OPENAI_KEY: ${{ inputs.openai_key }}
-    REDIS_URL: ${{ secrets.REDIS_URL }}
-    REDIS_TOKEN: ${{ secrets.REDIS_TOKEN }}
     INCLUDE_FEEDBACK: ${{ inputs.include-feedback }}

--- a/action.yml
+++ b/action.yml
@@ -23,12 +23,6 @@ inputs:
   openai_key:
     description: 'OpenAI API key for AI feedback. REQUIRED for AI feedback mode in GitHub Actions.'
     required: false
-  redis_url:
-    description: 'Redis URL for score export and caching. REQUIRED for AI feedback mode or score export in GitHub Actions.'
-    required: false
-  redis_token:
-    description: 'Redis token for authentication. REQUIRED for AI feedback mode or score export in GitHub Actions.'
-    required: false
   app_token:
     description: 'The application token for the autograder service.'
     required: false
@@ -54,6 +48,6 @@ runs:
     TEMPLATE_PRESET: ${{ inputs.template_preset }}
     FEEDBACK_TYPE: ${{ inputs.feedback-type }}
     OPENAI_KEY: ${{ inputs.openai_key }}
-    REDIS_URL: ${{ inputs.redis_url }}
-    REDIS_TOKEN: ${{ inputs.redis_token }}
+    REDIS_URL: ${{ secrets.REDIS_URL }}
+    REDIS_TOKEN: ${{ secrets.REDIS_TOKEN }}
     INCLUDE_FEEDBACK: ${{ inputs.include-feedback }}

--- a/action.yml
+++ b/action.yml
@@ -21,13 +21,13 @@ inputs:
     description: 'Optional custom grading template in JSON format. Required if template_preset is set to "custom".'
     required: false
   openai_key:
-    description: 'Optional OpenAI API key for generating AI-assisted feedback.'
+    description: 'OpenAI API key for AI feedback. REQUIRED for AI feedback mode in GitHub Actions.'
     required: false
   redis_url:
-    description: 'Optional URL for a Redis instance for caching.'
+    description: 'Redis URL for score export and caching. REQUIRED for AI feedback mode or score export in GitHub Actions.'
     required: false
   redis_token:
-    description: 'Optional authentication token for the Redis instance.'
+    description: 'Redis token for authentication. REQUIRED for AI feedback mode or score export in GitHub Actions.'
     required: false
   app_token:
     description: 'The application token for the autograder service.'

--- a/connectors/adapters/api/api_adapter.py
+++ b/connectors/adapters/api/api_adapter.py
@@ -39,10 +39,7 @@ class ApiAdapter(Port):
                        student_name,
                        student_credentials,
                        include_feedback=False,
-                       feedback_mode="default",
-                       openai_key=None,
-                       redis_url=None,
-                       redis_token=None):
+                       feedback_mode="default"):
         submission_files_dict = {}
         for submission_file in submission_files:
             if ".git" in submission_file.filename:
@@ -56,9 +53,6 @@ class ApiAdapter(Port):
             student_credentials=student_credentials,
             include_feedback=include_feedback,
             feedback_mode=feedback_mode,
-            openai_key=openai_key,
-            redis_url=redis_url,
-            redis_token=redis_token,
         )
 
 

--- a/connectors/adapters/api/api_entrypoint.py
+++ b/connectors/adapters/api/api_entrypoint.py
@@ -54,9 +54,6 @@ async def grade_submission_endpoint(
         custom_template: Optional[UploadFile] = File(None,description="A python file with custom tests that follows the template structure (in case of custom preset)"),
         feedback_json: Optional[UploadFile] = File(None, description="JSON file with feedback configuration (in case of custom preset)"),
         setup_json: Optional[UploadFile] = File(None, description="JSON file with commands configuration (in case of custom preset)"),
-        openai_key: Optional[str] = Form(None, description="OpenAI API key for AI feedback"),
-        redis_url: Optional[str] = Form(None, description="Redis URL for AI feedback"),
-        redis_token: Optional[str] = Form(None, description="Redis token for AI feedback"),
 ):
     try:
         logging.info("Received API request to grade submission.")
@@ -77,10 +74,7 @@ async def grade_submission_endpoint(
                                student_name=student_name,
                                student_credentials=student_credentials,
                                include_feedback=include_feedback,
-                               feedback_mode=feedback_type,
-                               openai_key=openai_key,
-                               redis_url=redis_url,
-                               redis_token=redis_token)
+                               feedback_mode=feedback_type)
         logging.info(f"Autograder request created successfully.")
 
 

--- a/connectors/adapters/github_action_adapter/github_adapter.py
+++ b/connectors/adapters/github_action_adapter/github_adapter.py
@@ -163,10 +163,6 @@ class GithubAdapter(Port):
         # Set credentials as environment variables
         if openai_key:
             os.environ["OPENAI_API_KEY"] = openai_key
-        if redis_url:
-            os.environ["REDIS_URL"] = redis_url
-        if redis_token:
-            os.environ["REDIS_TOKEN"] = redis_token
 
         
         print("Getting submission files from the repository...")

--- a/connectors/adapters/github_action_adapter/github_adapter.py
+++ b/connectors/adapters/github_action_adapter/github_adapter.py
@@ -159,6 +159,15 @@ class GithubAdapter(Port):
         """
         Creates an AutograderRequest object with the provided parameters.
         """
+        
+        # Set credentials as environment variables if provided by GitHub Actions
+        if openai_key:
+            os.environ["OPENAI_API_KEY"] = openai_key
+        if redis_url:
+            os.environ["REDIS_URL"] = redis_url
+        if redis_token:
+            os.environ["REDIS_TOKEN"] = redis_token
+        
         print("Getting submission files from the repository...")
         submission_files_dict = self.get_submission_files()
         print(submission_files_dict)
@@ -170,9 +179,6 @@ class GithubAdapter(Port):
             student_credentials=student_credentials,
             include_feedback=include_feedback,
             feedback_mode=feedback_mode,
-            openai_key=openai_key,
-            redis_url=redis_url,
-            redis_token=redis_token,
         )
         print(f"AutograderRequest created with {self.autograder_request.feedback_mode} feedback mode")
 

--- a/connectors/adapters/github_action_adapter/github_adapter.py
+++ b/connectors/adapters/github_action_adapter/github_adapter.py
@@ -160,7 +160,7 @@ class GithubAdapter(Port):
         Creates an AutograderRequest object with the provided parameters.
         """
         
-        # Set credentials as environment variables if provided by GitHub Actions
+        # Set credentials as environment variables
         if openai_key:
             os.environ["OPENAI_API_KEY"] = openai_key
         if redis_url:

--- a/connectors/adapters/github_action_adapter/github_adapter.py
+++ b/connectors/adapters/github_action_adapter/github_adapter.py
@@ -167,6 +167,7 @@ class GithubAdapter(Port):
             os.environ["REDIS_URL"] = redis_url
         if redis_token:
             os.environ["REDIS_TOKEN"] = redis_token
+
         
         print("Getting submission files from the repository...")
         submission_files_dict = self.get_submission_files()

--- a/connectors/adapters/github_action_adapter/github_entrypoint.py
+++ b/connectors/adapters/github_action_adapter/github_entrypoint.py
@@ -8,9 +8,9 @@ parser.add_argument("--student-name", type=str, required=True, help="The name of
 parser.add_argument("--feedback-type", type=str, default="default",help="The type of feedback to provide (default or ai)")
 parser.add_argument("--custom-template", type=str, required=False, help="Test Files for the submission (in case of custom preset)")
 parser.add_argument("--app_token", type=str, required=False, help="GitHub App Token")
-parser.add_argument("--openai-key", type=str, required=False, help="OpenAI API key for AI feedback")
-parser.add_argument("--redis-url", type=str, required=False, help="Redis URL for AI feedback")
-parser.add_argument("--redis-token", type=str, required=False, help="Redis token for AI feedback")
+parser.add_argument("--openai-key", type=str, required=False, help="OpenAI API key for AI feedback (GitHub Actions only)")
+parser.add_argument("--redis-url", type=str, required=False, help="Redis URL for score export and AI feedback (GitHub Actions only)")
+parser.add_argument("--redis-token", type=str, required=False, help="Redis token for score export and AI feedback (GitHub Actions only)")
 parser.add_argument("--include-feedback", type=str, required=False, help="Whether to include/generate feedback (true/false).")
 
 async def main():
@@ -25,9 +25,12 @@ async def main():
     template_preset = args.template_preset
     student_name = args.student_name
     feedback_type = args.feedback_type
+    
+    # Validate that AI feedback has required credentials
     if feedback_type == "ai":
         if not args.openai_key or not args.redis_url or not args.redis_token:
-            raise ValueError("OpenAI key, Redis URL, and Redis token are required for AI feedback.")
+            raise ValueError("OpenAI key, Redis URL, and Redis token are required for AI feedback in GitHub Actions.")
+    
     adapter = GithubAdapter(github_token,args.app_token)
     if args.template_preset == "custom":
         # Validate and load the custom template preset
@@ -44,6 +47,7 @@ async def main():
             raise ValueError("Invalid value for --include-feedback. Allowed values: 'true' or 'false'.")
         include_feedback = (val == "true")
 
+    # GitHub Actions must provide credentials for AI feedback
     adapter.create_request(
         submission_files=None,
         assignment_config=assignment_config,

--- a/connectors/adapters/github_action_adapter/github_entrypoint.py
+++ b/connectors/adapters/github_action_adapter/github_entrypoint.py
@@ -8,9 +8,9 @@ parser.add_argument("--student-name", type=str, required=True, help="The name of
 parser.add_argument("--feedback-type", type=str, default="default",help="The type of feedback to provide (default or ai)")
 parser.add_argument("--custom-template", type=str, required=False, help="Test Files for the submission (in case of custom preset)")
 parser.add_argument("--app_token", type=str, required=False, help="GitHub App Token")
-parser.add_argument("--openai-key", type=str, required=False, help="OpenAI API key for AI feedback")
-parser.add_argument("--redis-url", type=str, required=False, help="Redis URL for score export and AI feedback")
-parser.add_argument("--redis-token", type=str, required=False, help="Redis token for score export and AI feedback")
+parser.add_argument("--openai-key", type=str, required=False, help="OpenAI API key for AI feedback (required only for AI feedback mode)")
+parser.add_argument("--redis-url", type=str, required=False, help="Redis URL")
+parser.add_argument("--redis-token", type=str, required=False, help="Redis token")
 parser.add_argument("--include-feedback", type=str, required=False, help="Whether to include/generate feedback (true/false).")
 
 async def main():
@@ -28,8 +28,8 @@ async def main():
     
     # Validate that AI feedback has required credentials
     if feedback_type == "ai":
-        if not args.openai_key or not args.redis_url or not args.redis_token:
-            raise ValueError("OpenAI key, Redis URL, and Redis token are required for AI feedback in GitHub Actions.")
+        if not args.openai_key:
+            raise ValueError("OpenAI API key is required for AI feedback mode in GitHub Actions. Please configure OPENAI_API_KEY as a secret.")
     
     adapter = GithubAdapter(github_token,args.app_token)
     if args.template_preset == "custom":

--- a/connectors/adapters/github_action_adapter/github_entrypoint.py
+++ b/connectors/adapters/github_action_adapter/github_entrypoint.py
@@ -9,8 +9,6 @@ parser.add_argument("--feedback-type", type=str, default="default",help="The typ
 parser.add_argument("--custom-template", type=str, required=False, help="Test Files for the submission (in case of custom preset)")
 parser.add_argument("--app_token", type=str, required=False, help="GitHub App Token")
 parser.add_argument("--openai-key", type=str, required=False, help="OpenAI API key for AI feedback (required only for AI feedback mode)")
-parser.add_argument("--redis-url", type=str, required=False, help="Redis URL")
-parser.add_argument("--redis-token", type=str, required=False, help="Redis token")
 parser.add_argument("--include-feedback", type=str, required=False, help="Whether to include/generate feedback (true/false).")
 
 async def main():
@@ -55,8 +53,6 @@ async def main():
         student_credentials=github_token,
         feedback_mode=feedback_type,
         openai_key=args.openai_key,
-        redis_url=args.redis_url,
-        redis_token=args.redis_token,
         include_feedback=include_feedback,
     )
 

--- a/connectors/adapters/github_action_adapter/github_entrypoint.py
+++ b/connectors/adapters/github_action_adapter/github_entrypoint.py
@@ -8,9 +8,9 @@ parser.add_argument("--student-name", type=str, required=True, help="The name of
 parser.add_argument("--feedback-type", type=str, default="default",help="The type of feedback to provide (default or ai)")
 parser.add_argument("--custom-template", type=str, required=False, help="Test Files for the submission (in case of custom preset)")
 parser.add_argument("--app_token", type=str, required=False, help="GitHub App Token")
-parser.add_argument("--openai-key", type=str, required=False, help="OpenAI API key for AI feedback (GitHub Actions only)")
-parser.add_argument("--redis-url", type=str, required=False, help="Redis URL for score export and AI feedback (GitHub Actions only)")
-parser.add_argument("--redis-token", type=str, required=False, help="Redis token for score export and AI feedback (GitHub Actions only)")
+parser.add_argument("--openai-key", type=str, required=False, help="OpenAI API key for AI feedback")
+parser.add_argument("--redis-url", type=str, required=False, help="Redis URL for score export and AI feedback")
+parser.add_argument("--redis-token", type=str, required=False, help="Redis token for score export and AI feedback")
 parser.add_argument("--include-feedback", type=str, required=False, help="Whether to include/generate feedback (true/false).")
 
 async def main():

--- a/connectors/models/autograder_request.py
+++ b/connectors/models/autograder_request.py
@@ -10,9 +10,6 @@ class AutograderRequest(BaseModel):
     student_credentials: Optional[str] = None
     include_feedback: bool = False
     feedback_mode: str = "default"
-    openai_key: Optional[str] = None
-    redis_url: Optional[str] = None
-    redis_token: Optional[str] = None
     criteria_tree: Optional[Any] = None
     reporter: Optional[Any] = None
     feedback_report: Optional[Any] = None

--- a/connectors/port.py
+++ b/connectors/port.py
@@ -35,10 +35,7 @@ class Port(ABC):
                        assignment_config: AssignmentConfig,
                        student_name,
                        student_credentials,
-                       feedback_mode="default",
-                       openai_key=None,
-                       redis_url=None,
-                       redis_token=None):
+                       feedback_mode="default"):
         """
         Abstract method to create an AutograderRequest object.
         This method should be implemented by the concrete Port classes.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,16 +58,6 @@ if [[ -n "$OPENAI_KEY" ]]; then
     args+=("--openai-key" "$OPENAI_KEY")
 fi
 
-if [[ -n "$REDIS_URL" ]]; then
-    echo "Adding Redis URL to arguments."
-    args+=("--redis-url" "$REDIS_URL")
-fi
-
-if [[ -n "$REDIS_TOKEN" ]]; then
-    echo "Adding Redis token to arguments."
-    args+=("--redis-token" "$REDIS_TOKEN")
-fi
-
 if [[ -n "$INCLUDE_FEEDBACK" ]]; then
   args+=("--include-feedback" "$INCLUDE_FEEDBACK")
 fi

--- a/tests/playroom/essay_playroom.py
+++ b/tests/playroom/essay_playroom.py
@@ -260,8 +260,7 @@ def run_essay_playroom():
         assignment_config=assignment_config,
         student_name="Alex Johnson",
         include_feedback=True,
-        feedback_mode="ai",
-        openai_key=openai_key
+        feedback_mode="ai"
     )
 
     # Execute grading

--- a/tests/unit/test_facade.py
+++ b/tests/unit/test_facade.py
@@ -170,7 +170,7 @@ class TestAutograderFacade(unittest.TestCase):
         # Assert
         self.assertEqual(response.status, "fail")
         self.assertEqual(response.final_score, 0.0)
-        self.assertIn("OpenAI key, Redis URL, and Redis token are required", response.feedback)
+        self.assertIn("OpenAI key, Redis URL, and Redis token are required for AI feedback mode", response.feedback)
 
     @patch('autograder.autograder_facade.PreFlight')
     def test_preflight_failure_stops_processing(self, mock_preflight):

--- a/tests/unit/test_facade.py
+++ b/tests/unit/test_facade.py
@@ -160,8 +160,7 @@ class TestAutograderFacade(unittest.TestCase):
             assignment_config=self.mock_assignment_config,
             student_name="test_student",
             include_feedback=True,
-            feedback_mode="ai",
-            openai_key=None  # missing keys
+            feedback_mode="ai"
         )
 
         # Act


### PR DESCRIPTION

From what I understood from our call, I decided to use this approach: the teacher sets up a repository environment in GitHub Actions with their OpenAI API key, while the Redis credentials are configured as organization secrets.