### PR TITLE
87 prettify test names

### DIFF
--- a/autograder/builder/template_library/templates/api_testing.py
+++ b/autograder/builder/template_library/templates/api_testing.py
@@ -20,7 +20,7 @@ class HealthCheckTest(TestFunction):
 
     @property
     def name(self):
-        return "health_check"
+        return "Health Check"
 
     @property
     def description(self):
@@ -86,7 +86,7 @@ class CheckResponseJsonTest(TestFunction):
 
     @property
     def name(self):
-        return "check_response_json"
+        return "Check Response JSON"
 
     @property
     def description(self):
@@ -192,8 +192,8 @@ class ApiTestingTemplate(Template):
 
 
         self.tests = {
-            "health_check": HealthCheckTest(self.executor),
-            "check_response_json": CheckResponseJsonTest(self.executor),
+            "Health Check": HealthCheckTest(self.executor),
+            "Check Response JSON": CheckResponseJsonTest(self.executor),
         }
 
 
@@ -285,8 +285,8 @@ if __name__ == "__main__":
                     "api_functionality": {
                         "weight": 100,
                         "tests": [
-                            {"name": "health_check", "calls": [["/health"]]},
-                            {"name": "check_response_json", "calls": [["/api/user", "userId", 1]]}
+                            {"name": "Health Check", "calls": [["/health"]]},
+                            {"name": "Check Response JSON", "calls": [["/api/user", "userId", 1]]}
                         ]
                     }
                 }
@@ -315,14 +315,14 @@ if __name__ == "__main__":
 
         logging.info("\n--- 3. Running Tests ---")
 
-        health_check_test = template.get_test("health_check")
+        health_check_test = template.get_test("Health Check")
         health_result = health_check_test.execute("/health")
 
         logging.info("\n[Health Check Result]")
         logging.info(f"  Score: {health_result.score}")
         logging.info(f"  Report: {health_result.report}")
 
-        json_check_test = template.get_test("check_response_json")
+        json_check_test = template.get_test("Check Response JSON")
         json_result = json_check_test.execute("/api/user", "userId", 1)
 
         logging.info("\n[JSON Check Result]")

--- a/autograder/builder/template_library/templates/essay_grader.py
+++ b/autograder/builder/template_library/templates/essay_grader.py
@@ -10,7 +10,7 @@ from autograder.core.models.test_result import TestResult
 
 class ClarityAndCohesionTest(TestFunction):
     @property
-    def name(self): return "clarity_and_cohesion"
+    def name(self): return "Clarity and Cohesion"
     @property
     def description(self): return "Avalia a clareza geral e o fluxo da redação."
     @property
@@ -22,9 +22,10 @@ class ClarityAndCohesionTest(TestFunction):
         prompt = "Em uma escala de 0 a 100, quão claro e bem estruturado é a redação? Avalie o fluxo lógico dos argumentos, as transições entre parágrafos e a legibilidade geral."
         return ai_executor.add_test(self.name,  prompt)
 
+
 class GrammarAndSpellingTest(TestFunction):
     @property
-    def name(self): return "grammar_and_spelling"
+    def name(self): return "Grammar and Spelling"
     @property
     def description(self): return "Verifica a redação em busca de erros gramaticais, de ortografia e de pontuação."
     @property
@@ -36,9 +37,10 @@ class GrammarAndSpellingTest(TestFunction):
         prompt = "Em uma escala de 0 a 100, avalie a precisão gramatical da redação. Considere ortografia, pontuação, estrutura das frases e concordância verbal."
         return ai_executor.add_test(self.name,  prompt)
 
+
 class ArgumentStrengthTest(TestFunction):
     @property
-    def name(self): return "argument_strength"
+    def name(self): return "Argument Strength"
     @property
     def description(self): return "Avalia a força e o suporte dos argumentos apresentados."
     @property
@@ -50,9 +52,10 @@ class ArgumentStrengthTest(TestFunction):
         prompt = "Avalie a força dos argumentos na redação em uma escala de 0 a 100. As alegações são bem apoiadas com evidências e exemplos? O raciocínio é sólido e persuasivo?"
         return ai_executor.add_test(self.name,  prompt)
 
+
 class ThesisStatementTest(TestFunction):
     @property
-    def name(self): return "thesis_statement"
+    def name(self): return "Thesis Statement"
     @property
     def description(self): return "Avalia a clareza e a eficácia da declaração de tese."
     @property
@@ -64,9 +67,10 @@ class ThesisStatementTest(TestFunction):
         prompt = "Em uma escala de 0 a 100, quão forte e clara é a declaração de tese da redação? Ela apresenta uma posição clara e defensável que é mantida ao longo do texto?"
         return ai_executor.add_test(self.name,  prompt)
 
+
 class AdherenceToPromptTest(TestFunction):
     @property
-    def name(self): return "adherence_to_prompt"
+    def name(self): return "Adherence to Prompt"
     @property
     def description(self): return "Verifica quão bem a redação aborda os requisitos específicos do tema proposto."
     @property
@@ -80,9 +84,10 @@ class AdherenceToPromptTest(TestFunction):
         prompt = f"Dado o tema da redação '{prompt_requirements}', quão bem a redação enviada aborda todas as partes da questão? Avalie em uma escala de 0 a 100."
         return ai_executor.add_test(self.name,  prompt)
 
+
 class OriginalityAndPlagiarismTest(TestFunction):
     @property
-    def name(self): return "originality_and_plagiarism"
+    def name(self): return "Originality and Plagiarism"
     @property
     def description(self): return "Uma verificação simplificada de originalidade procurando por frases comuns ou conteúdo copiado."
     @property
@@ -94,9 +99,10 @@ class OriginalityAndPlagiarismTest(TestFunction):
         prompt = "Em uma escala de 0 a 100, avalie a originalidade da redação. Embora você não possa realizar uma pesquisa na web, avalie o texto em busca de sinais de conteúdo não original, como frases genéricas ou argumentos excessivamente comuns que possam sugerir plágio."
         return ai_executor.add_test(self.name,  prompt)
 
+
 class TopicConnectionTest(TestFunction):
     @property
-    def name(self): return "topic_connection"
+    def name(self): return "Topic Connection"
     @property
     def description(self): return "Verifica se a redação estabelece com sucesso uma conexão entre dois tópicos especificados."
     @property
@@ -111,9 +117,10 @@ class TopicConnectionTest(TestFunction):
         prompt = f"Em uma escala de 0 a 100, quão eficazmente a redação estabelece uma conexão significativa entre os conceitos de '{topic1}' e '{topic2}'? Avalie a profundidade e a clareza da ligação."
         return ai_executor.add_test(self.name,  prompt)
 
+
 class CounterargumentHandlingTest(TestFunction):
     @property
-    def name(self): return "counterargument_handling"
+    def name(self): return "Counterargument Handling"
     @property
     def description(self): return "Avalia quão bem a redação reconhece e refuta potenciais contra-argumentos."
     @property
@@ -125,9 +132,10 @@ class CounterargumentHandlingTest(TestFunction):
         prompt = "Em uma escala de 0 a 100, avalie quão bem a redação aborda potenciais contra-argumentos. Ele antecipa pontos de vista opostos e fornece refutações bem pensadas?"
         return ai_executor.add_test(self.name,  prompt)
 
+
 class IntroductionAndConclusionTest(TestFunction):
     @property
-    def name(self): return "introduction_and_conclusion"
+    def name(self): return "Introduction and Conclusion"
     @property
     def description(self): return "Avalia a eficácia da introdução e da conclusão da redação."
     @property
@@ -139,9 +147,10 @@ class IntroductionAndConclusionTest(TestFunction):
         prompt = "Em uma escala de 0 a 100, avalie a qualidade da introdução e da conclusão. A introdução consegue engajar o leitor e apresentar a tese de forma eficaz? A conclusão fornece um resumo sólido e oferece percepções finais?"
         return ai_executor.add_test(self.name,  prompt)
 
+
 class EvidenceQualityTest(TestFunction):
     @property
-    def name(self): return "evidence_quality"
+    def name(self): return "Evidence Quality"
     @property
     def description(self): return "Avalia a relevância e a qualidade das evidências usadas para apoiar as alegações."
     @property
@@ -153,9 +162,10 @@ class EvidenceQualityTest(TestFunction):
         prompt = "Em uma escala de 0 a 100, avalie a qualidade das evidências usadas na redação. As evidências são relevantes, críveis e suficientes para apoiar os argumentos principais?"
         return ai_executor.add_test(self.name,  prompt)
 
+
 class ToneAndStyleTest(TestFunction):
     @property
-    def name(self): return "tone_and_style"
+    def name(self): return "Tone and Style"
     @property
     def description(self): return "Avalia se o tom e o estilo de escrita da redação são apropriados para o tópico e o público."
     @property
@@ -169,9 +179,10 @@ class ToneAndStyleTest(TestFunction):
         prompt = f"Em uma escala de 0 a 100, a redação mantém um tom e estilo '{expected_tone}' apropriados? Avalie a voz do autor, a escolha de palavras e o profissionalismo geral."
         return ai_executor.add_test(self.name,  prompt)
 
+
 class VocabularyAndDictionTest(TestFunction):
     @property
-    def name(self): return "vocabulary_and_diction"
+    def name(self): return "Vocabulary and Diction"
     @property
     def description(self): return "Avalia a sofisticação e a variedade do vocabulário utilizado."
     @property
@@ -183,9 +194,10 @@ class VocabularyAndDictionTest(TestFunction):
         prompt = "Em uma escala de 0 a 100, avalie o uso de vocabulário pelo autor. A linguagem é precisa, variada e apropriadamente sofisticada para o tópico?"
         return ai_executor.add_test(self.name,  prompt)
 
+
 class SentenceStructureVarietyTest(TestFunction):
     @property
-    def name(self): return "sentence_structure_variety"
+    def name(self): return "Sentence Structure Variety"
     @property
     def description(self): return "Verifica a presença de estruturas de frase variadas e complexas."
     @property
@@ -197,9 +209,10 @@ class SentenceStructureVarietyTest(TestFunction):
         prompt = "Em uma escala de 0 a 100, avalie a variedade das estruturas de frase na redação. O autor usa uma mistura de frases simples, compostas e complexas para criar um ritmo mais envolvente?"
         return ai_executor.add_test(self.name,  prompt)
 
+
 class BiasDetectionTest(TestFunction):
     @property
-    def name(self): return "bias_detection"
+    def name(self): return "Bias Detection"
     @property
     def description(self): return "Identifica potencial viés ou opiniões não suportadas na redação."
     @property
@@ -211,9 +224,10 @@ class BiasDetectionTest(TestFunction):
         prompt = "Em uma escala de 0 a 100, avalie a objetividade e o viés da redação. O autor apresenta uma visão equilibrada, ou o texto se baseia em opiniões não suportadas e linguagem emocionalmente carregada?"
         return ai_executor.add_test(self.name,  prompt)
 
+
 class ExampleClarityTest(TestFunction):
     @property
-    def name(self): return "example_clarity"
+    def name(self): return "Example Clarity"
     @property
     def description(self): return "Avalia quão claros e ilustrativos são os exemplos."
     @property
@@ -225,9 +239,10 @@ class ExampleClarityTest(TestFunction):
         prompt = "Em uma escala de 0 a 100, quão claros e eficazes são os exemplos usados na redação? Eles realmente ilustram os pontos que o autor está tentando defender?"
         return ai_executor.add_test(self.name,  prompt)
 
+
 class LogicalFallacyCheckTest(TestFunction):
     @property
-    def name(self): return "logical_fallacy_check"
+    def name(self): return "Logical Fallacy Check"
     @property
     def description(self): return "Verifica a presença de falácias lógicas comuns nos argumentos."
     @property
@@ -252,24 +267,24 @@ class EssayGraderTemplate(Template):
         self.executor = ai_executor
         self.tests = {
             # Original Tests
-            "clarity_and_cohesion": ClarityAndCohesionTest(),
-            "grammar_and_spelling": GrammarAndSpellingTest(),
-            "argument_strength": ArgumentStrengthTest(),
-            "thesis_statement": ThesisStatementTest(),
-            "adherence_to_prompt": AdherenceToPromptTest(),
-            "originality_and_plagiarism": OriginalityAndPlagiarismTest(),
+            "Clarity and Cohesion": ClarityAndCohesionTest(),
+            "Grammar and Spelling": GrammarAndSpellingTest(),
+            "Argument Strength": ArgumentStrengthTest(),
+            "Thesis Statement": ThesisStatementTest(),
+            "Adherence to Prompt": AdherenceToPromptTest(),
+            "Originality and Plagiarism": OriginalityAndPlagiarismTest(),
 
             # 10 New Advanced Tests
-            "topic_connection": TopicConnectionTest(),
-            "counterargument_handling": CounterargumentHandlingTest(),
-            "introduction_and_conclusion": IntroductionAndConclusionTest(),
-            "evidence_quality": EvidenceQualityTest(),
-            "tone_and_style": ToneAndStyleTest(),
-            "vocabulary_and_diction": VocabularyAndDictionTest(),
-            "sentence_structure_variety": SentenceStructureVarietyTest(),
-            "bias_detection": BiasDetectionTest(),
-            "example_clarity": ExampleClarityTest(),
-            "logical_fallacy_check": LogicalFallacyCheckTest(),
+            "Topic Connection": TopicConnectionTest(),
+            "Counterargument Handling": CounterargumentHandlingTest(),
+            "Introduction and Conclusion": IntroductionAndConclusionTest(),
+            "Evidence Quality": EvidenceQualityTest(),
+            "Tone and Style": ToneAndStyleTest(),
+            "Vocabulary and Diction": VocabularyAndDictionTest(),
+            "Sentence Structure Variety": SentenceStructureVarietyTest(),
+            "Bias Detection": BiasDetectionTest(),
+            "Example Clarity": ExampleClarityTest(),
+            "Logical Fallacy Check": LogicalFallacyCheckTest(),
         }
 
     @property

--- a/autograder/builder/template_library/templates/input_output.py
+++ b/autograder/builder/template_library/templates/input_output.py
@@ -20,7 +20,7 @@ class ExpectOutputTest(TestFunction):
 
     @property
     def name(self):
-        return "expect_output"
+        return "Expect Output"
 
     @property
     def description(self):
@@ -134,7 +134,7 @@ class InputOutputTemplate(Template):
         else:
             self.executor = None
         self.tests = {
-            "expect_output": ExpectOutputTest(self.executor),
+            "Expect Output": ExpectOutputTest(self.executor),
         }
 
     def _setup_environment(self):
@@ -211,8 +211,8 @@ if __name__ == "__main__":
                     "calculation_tests": {
                         "weight": 100,
                         "tests": [
-                            {"name": "expect_output", "calls": [[["sum", 2, 2], "4.0"]]},
-                            {"name": "expect_output", "calls": [[["subtract", 10, 5], "5.0"]]}
+                            {"name": "Expect Output", "calls": [[["sum", 2, 2], "4.0"]]},
+                            {"name": "Expect Output", "calls": [[["subtract", 10, 5], "5.0"]]}
                         ]
                     }
                 }
@@ -242,14 +242,14 @@ if __name__ == "__main__":
         print("\n--- 3. Running Tests ---")
 
         # Test 1: Sum (Will pass)
-        test_func = template.get_test("expect_output")
+        test_func = template.get_test("Expect Output")
         sum_result = test_func.execute(["sum", 2, 2], "4.0")
         print("\n[Sum Test Result]")
         print(f"  Score: {sum_result.score}")
         print(f"  Report: {sum_result.report}")
 
         # Test 2: Sum (Will fail)
-        test_func = template.get_test("expect_output")
+        test_func = template.get_test("Expect Output")
         sum_result = test_func.execute(["sum", 2, 2], "3.0")
         print("\n[Sum Test Result]")
         print(f"  Score: {sum_result.score}")

--- a/autograder/builder/template_library/templates/web_dev.py
+++ b/autograder/builder/template_library/templates/web_dev.py
@@ -16,7 +16,7 @@ from autograder.core.models.test_result import TestResult
 class HasClass(TestFunction):
     @property
     def name(self):
-        return "has_class"
+        return "Has Class"
 
     @property
     def description(self):
@@ -63,7 +63,7 @@ class HasClass(TestFunction):
 
 class CheckBootstrapLinked(TestFunction):
     @property
-    def name(self): return "check_bootstrap_linked"
+    def name(self): return "Check Bootstrap Linked"
 
     @property
     def description(self): return "Verifica se o framework Bootstrap (CSS ou JS) está vinculado no arquivo HTML."
@@ -91,7 +91,7 @@ class CheckBootstrapLinked(TestFunction):
 class CheckInternalLinks(TestFunction):
     @property
     def name(self):
-        return "check_internal_links"
+        return "Check Internal Links"
 
     @property
     def description(self):
@@ -132,9 +132,11 @@ class CheckInternalLinks(TestFunction):
             report=report,
             parameters={"required_count": required_count}
         )
+
+
 class HasTag(TestFunction):
     @property
-    def name(self): return "has_tag"
+    def name(self): return "Has Tag"
     @property
     def description(self): return "Verifica se uma tag HTML específica aparece um número mínimo de vezes."
     @property
@@ -157,9 +159,10 @@ class HasTag(TestFunction):
             parameters={"tag": tag, "required_count": required_count}
         )
 
+
 class HasForbiddenTag(TestFunction):
     @property
-    def name(self): return "has_forbidden_tag"
+    def name(self): return "Has Forbidden Tag"
     @property
     def description(self): return "Verifica a presença de uma tag HTML proibida."
     @property
@@ -176,9 +179,10 @@ class HasForbiddenTag(TestFunction):
         report = f"A tag `<{tag}>` foi encontrada e é proibida." if found else f"A tag `<{tag}>` não foi encontrada, ótimo!"
         return TestResult(test_name=self.name, score=score, report=report, parameters={"tag": tag})
 
+
 class HasAttribute(TestFunction):
     @property
-    def name(self): return "has_attribute"
+    def name(self): return "Has Attribute"
     @property
     def description(self): return "Verifica se um atributo HTML específico está presente em qualquer tag, um número mínimo de vezes."
     @property
@@ -201,10 +205,11 @@ class HasAttribute(TestFunction):
             parameters={"attribute": attribute, "required_count": required_count}
         )
 
+
 class CheckNoUnclosedTags(TestFunction):
     @property
     def name(self):
-        return "check_no_unclosed_tags"
+        return "Check no Unclosed Tags"
     @property
     def description(self):
         return "Detecta tags HTML que foram abertas mas não foram fechadas."
@@ -248,9 +253,10 @@ class CheckNoUnclosedTags(TestFunction):
         )
         return TestResult(test_name=self.name, score=score, report=report)
 
+
 class CheckNoInlineStyles(TestFunction):
     @property
-    def name(self): return "check_no_inline_styles"
+    def name(self): return "Check no Inline Styles"
     @property
     def description(self): return "Garante que nenhum estilo em linha (inline) seja usado no arquivo HTML."
     @property
@@ -264,9 +270,10 @@ class CheckNoInlineStyles(TestFunction):
         report = f"Foi encontrado {found_count} inline styles (`style='...'`). Mova todas as regras de estilo para seu arquivo `.css`." if found_count > 0 else "Excelente! Nenhum estilo inline foi encontrado."
         return TestResult(test_name=self.name, score=score, report=report)
 
+
 class UsesSemanticTags(TestFunction):
     @property
-    def name(self): return "uses_semantic_tags"
+    def name(self): return "Uses Semantic Tags"
     @property
     def description(self): return "Verifica se o HTML usa pelo menos uma tag semântica comum."
     @property
@@ -281,9 +288,10 @@ class UsesSemanticTags(TestFunction):
         report = "Utilizou tags semânticas." if found else "Não usou nenhuma tag do tipo (`<article>`, `<section>`, `<nav>`) na estrutura do HTML."
         return TestResult(test_name=self.name, score=score, report=report)
 
+
 class CheckCssLinked(TestFunction):
     @property
-    def name(self): return "check_css_linked"
+    def name(self): return "Check CSS Linked"
     @property
     def description(self): return "Verifica se uma folha de estilo CSS externa está vinculada no HTML."
     @property
@@ -298,9 +306,10 @@ class CheckCssLinked(TestFunction):
         report = "Arquivo CSS está corretamente linkado com o HTML." if found else "Não foi encontrada a tag `<link rel='stylesheet'>` no seu HTML."
         return TestResult(test_name=self.name, score=score, report=report)
 
+
 class CssUsesProperty(TestFunction):
     @property
-    def name(self): return "css_uses_property"
+    def name(self): return "CSS Uses Property"
     @property
     def description(self): return "Verifica se um par de propriedade e valor CSS específico existe."
     @property
@@ -318,9 +327,10 @@ class CssUsesProperty(TestFunction):
         report = f"A propriedade `{prop}: {value};` foi encontrada." if found else f"A propriedade CSS `{prop}: {value};` não foi encontrada."
         return TestResult(test_name=self.name, score=score, report=report, parameters={"prop": prop, "value": value})
 
+
 class CountOverUsage(TestFunction):
     @property
-    def name(self): return "count_over_usage"
+    def name(self): return "Count Over Usage"
     @property
     def description(self): return "Penaliza o uso de uma string de texto específica se exceder uma contagem máxima permitida."
     @property
@@ -342,9 +352,10 @@ class CountOverUsage(TestFunction):
             parameters={"text": text, "max_allowed": max_allowed}
         )
 
+
 class JsUsesFeature(TestFunction):
     @property
-    def name(self): return "js_uses_feature"
+    def name(self): return "JS Uses Feature"
     @property
     def description(self): return "Realiza uma busca de string simples para verificar se uma funcionalidade específica está presente."
     @property
@@ -360,9 +371,10 @@ class JsUsesFeature(TestFunction):
         report = f"A funcionalidade `{feature}` foi implementada." if found else f"A funcionalidade JavaScript `{feature}` não foi encontrada no seu código."
         return TestResult(test_name=self.name, score=score, report=report, parameters={"feature": feature})
 
+
 class UsesForbiddenMethod(TestFunction):
     @property
-    def name(self): return "uses_forbidden_method"
+    def name(self): return "Uses Forbidden Method"
     @property
     def description(self): return "Verifica e penaliza o uso de um método ou palavra-chave proibida."
     @property
@@ -378,9 +390,10 @@ class UsesForbiddenMethod(TestFunction):
         report = f"Penalidade: Método proibido `{method}()` detectado." if found else f"Ótimo! O método proibido `{method}()` não foi usado."
         return TestResult(test_name=self.name, score=score, report=report, parameters={"method": method})
 
+
 class CountGlobalVars(TestFunction):
     @property
-    def name(self): return "count_global_vars"
+    def name(self): return "Count Global Vars"
     @property
     def description(self): return "Conta o número de variáveis declaradas no escopo global."
     @property
@@ -401,9 +414,10 @@ class CountGlobalVars(TestFunction):
             parameters={"max_allowed": max_allowed}
         )
 
+
 class CheckHeadingsSequential(TestFunction):
     @property
-    def name(self): return "check_headings_sequential"
+    def name(self): return "Check Headings Sequential"
     @property
     def description(self):
         return "Verifica se os níveis de cabeçalho não pulam níveis."
@@ -436,9 +450,10 @@ class CheckHeadingsSequential(TestFunction):
         )
         return TestResult(test_name=self.name, score=score, report=report)
 
+
 class CheckAllImagesHaveAlt(TestFunction):
     @property
-    def name(self): return "check_all_images_have_alt"
+    def name(self): return "Check all Images Have alt"
     @property
     def description(self): return "Verifica se todas as tags `<img>` possuem um atributo `alt` não vazio."
     @property
@@ -456,9 +471,10 @@ class CheckAllImagesHaveAlt(TestFunction):
         report = f"{with_alt} de {len(images)} imagens tem o atributo `alt` preenchido."
         return TestResult(test_name=self.name, score=score, report=report)
 
+
 class CheckHtmlDirectChildren(TestFunction):
     @property
-    def name(self): return "check_html_direct_children"
+    def name(self): return "Check HTML Direct Children"
     @property
     def description(self): return "Garante que os únicos filhos diretos da tag `<html>` são `<head>` e `<body>`."
     @property
@@ -476,9 +492,10 @@ class CheckHtmlDirectChildren(TestFunction):
         report = "Estrutura da tag <html> está correta." if is_valid else "A tag <html> deve conter apenas as tags <head> e <body> como filhos diretos."
         return TestResult(test_name=self.name, score=100 if is_valid else 0, report=report)
 
+
 class CheckTagNotInside(TestFunction):
     @property
-    def name(self): return "check_tag_not_inside"
+    def name(self): return "Check Tag not Inside"
     @property
     def description(self): return "Verifica se uma tag específica não está aninhada em nenhum lugar dentro de outra tag específica."
     @property
@@ -501,9 +518,10 @@ class CheckTagNotInside(TestFunction):
             parameters={"child_tag": child_tag, "parent_tag": parent_tag}
         )
 
+
 class CheckInternalLinksToArticle(TestFunction):
     @property
-    def name(self): return "check_internal_links_to_article"
+    def name(self): return "Check Internal Links to Article"
     @property
     def description(self): return "Verifica a existência de um número mínimo de links âncora internos apontando para IDs em tags `<article>`."
     @property
@@ -539,9 +557,10 @@ class CheckInternalLinksToArticle(TestFunction):
             parameters={"required_count": required_count}
         )
 
+
 class HasStyle(TestFunction):
     @property
-    def name(self): return "has_style"
+    def name(self): return "Has Style"
     @property
     def description(self): return "Verifica se uma regra de estilo CSS específica aparece um número mínimo de vezes."
     @property
@@ -563,9 +582,10 @@ class HasStyle(TestFunction):
             parameters={"style": style, "required_count": count}
         )
 
+
 class CheckHeadDetails(TestFunction):
     @property
-    def name(self): return "check_head_details"
+    def name(self): return "Check Head Details"
     @property
     def description(self): return "Verifica se uma tag de detalhe específica existe na seção `<head>`."
     @property
@@ -590,9 +610,10 @@ class CheckHeadDetails(TestFunction):
             parameters={"detail_tag": detail_tag}
         )
 
+
 class CheckAttributeAndValue(TestFunction):
     @property
-    def name(self): return "check_attribute_and_value"
+    def name(self): return "Check Attribute and Value"
     @property
     def description(self): return "Verifica se uma tag HTML específica contém um atributo específico com um determinado valor."
     @property
@@ -616,9 +637,10 @@ class CheckAttributeAndValue(TestFunction):
             parameters={"tag": tag, "attribute": attribute, "value": value}
         )
 
+
 class CheckDirExists(TestFunction):
     @property
-    def name(self): return "check_dir_exists"
+    def name(self): return "Check dir Exists"
     @property
     def description(self): return "Verifica se um diretório específico existe no envio."
     @property
@@ -635,9 +657,10 @@ class CheckDirExists(TestFunction):
         report = f"O diretório '{dir_path}' existe." if exists else f"O diretório '{dir_path}' não existe."
         return TestResult(test_name=self.name, score=score, report=report, parameters={"dir_path": dir_path})
 
+
 class CheckProjectStructure(TestFunction):
     @property
-    def name(self): return "check_project_structure"
+    def name(self): return "Check Project Structure"
     @property
     def description(self): return "Verifica se o caminho da estrutura esperada existe nos arquivos de envio."
     @property
@@ -659,9 +682,10 @@ class CheckProjectStructure(TestFunction):
             parameters={"expected_structure": expected_structure}
         )
 
+
 class CheckIdSelectorOverUsage(TestFunction):
     @property
-    def name(self): return "check_id_selector_over_usage"
+    def name(self): return "Check ID Selector Over Usage"
     @property
     def description(self): return "Conta seletores de ID válidos no CSS."
     @property
@@ -687,9 +711,10 @@ class CheckIdSelectorOverUsage(TestFunction):
             parameters={"max_allowed": max_allowed}
         )
 
+
 class UsesRelativeUnits(TestFunction):
     @property
-    def name(self): return "uses_relative_units"
+    def name(self): return "Uses Relative Units"
     @property
     def description(self): return "Verifica se o arquivo CSS usa unidades relativas como em, rem, %, vh, vw."
     @property
@@ -703,9 +728,10 @@ class UsesRelativeUnits(TestFunction):
         report = "Estão sendo utilizadas medidas relativas no CSS." if found else "Não foram utilizadas medidas relativas como (em, rem, %, vh, vw) no seu CSS."
         return TestResult(test_name=self.name, score=score, report=report)
 
+
 class CheckMediaQueries(TestFunction):
     @property
-    def name(self): return "check_media_queries"
+    def name(self): return "Check Media Queries"
     @property
     def description(self): return "Verifica se existem media queries no arquivo CSS."
     @property
@@ -719,9 +745,10 @@ class CheckMediaQueries(TestFunction):
         report = "Media queries estão sendo utilizadas no CSS." if found else "Não foi encontrado o uso de media queries no seu CSS."
         return TestResult(test_name=self.name, score=score, report=report)
 
+
 class CheckFlexboxUsage(TestFunction):
     @property
-    def name(self): return "check_flexbox_usage"
+    def name(self): return "Check Flexbox Usage"
     @property
     def description(self): return "Verifica se propriedades Flexbox são usadas no arquivo CSS."
     @property
@@ -735,9 +762,10 @@ class CheckFlexboxUsage(TestFunction):
         report = "Propriedades `flexbox` estão sendo utilizadas no CSS." if found else "Propriedades `flexbox` não foram encontradas no seu CSS."
         return TestResult(test_name=self.name, score=score, report=report)
 
+
 class CheckBootstrapUsage(TestFunction):
     @property
-    def name(self): return "check_bootstrap_usage"
+    def name(self): return "Check Bootstrap Usage"
     @property
     def description(self): return "Verifica se o Bootstrap está vinculado no arquivo HTML."
     @property
@@ -757,7 +785,7 @@ class CheckBootstrapUsage(TestFunction):
 class LinkPointsToPageWithQueryParam(TestFunction):
     @property
     def name(self):
-        return "link_points_to_page_with_query_param"
+        return "Link Points to Page with Query Param"
 
     @property
     def description(self):
@@ -802,7 +830,7 @@ class LinkPointsToPageWithQueryParam(TestFunction):
 class JsUsesQueryStringParsing(TestFunction):
     @property
     def name(self):
-        return "js_uses_query_string_parsing"
+        return "JS Uses Query String Parsing"
 
     @property
     def description(self):
@@ -828,7 +856,7 @@ class JsUsesQueryStringParsing(TestFunction):
 class JsHasJsonArrayWithId(TestFunction):
     @property
     def name(self):
-        return "js_has_json_array_with_id"
+        return "JS Has JSON Array with ID"
 
     @property
     def description(self):
@@ -875,7 +903,7 @@ class JsHasJsonArrayWithId(TestFunction):
 class JsUsesDomManipulation(TestFunction):
     @property
     def name(self):
-        return "js_uses_dom_manipulation"
+        return "JS Uses Dom Manipulation"
 
     @property
     def description(self):
@@ -910,7 +938,7 @@ class JsUsesDomManipulation(TestFunction):
 class HasNoJsFramework(TestFunction):
     @property
     def name(self):
-        return "has_no_js_framework"
+        return "Has no JS Framework"
 
     @property
     def description(self):
@@ -974,41 +1002,41 @@ class WebDevTemplate(Template):
 
     def __init__(self, clean=False):
         self.tests = {
-            "has_class": HasClass(),
-            "check_bootstrap_linked": CheckBootstrapLinked(),
-            "check_internal_links": CheckInternalLinks(),
-            "has_tag": HasTag(),
-            "has_forbidden_tag": HasForbiddenTag(),
-            "has_attribute": HasAttribute(),
-            "check_no_unclosed_tags": CheckNoUnclosedTags(),
-            "check_no_inline_styles": CheckNoInlineStyles(),
-            "uses_semantic_tags": UsesSemanticTags(),
-            "check_css_linked": CheckCssLinked(),
-            "css_uses_property": CssUsesProperty(),
-            "count_over_usage": CountOverUsage(),
-            "js_uses_feature": JsUsesFeature(),
-            "uses_forbidden_method": UsesForbiddenMethod(),
-            "count_global_vars": CountGlobalVars(),
-            "check_headings_sequential": CheckHeadingsSequential(),
-            "check_all_images_have_alt": CheckAllImagesHaveAlt(),
-            "check_html_direct_children": CheckHtmlDirectChildren(),
-            "check_tag_not_inside": CheckTagNotInside(),
-            "check_internal_links_to_article": CheckInternalLinksToArticle(),
-            "has_style": HasStyle(),
-            "check_head_details": CheckHeadDetails(),
-            "check_attribute_and_value": CheckAttributeAndValue(),
-            "check_dir_exists": CheckDirExists(),
-            "check_project_structure": CheckProjectStructure(),
-            "check_id_selector_over_usage": CheckIdSelectorOverUsage(),
-            "uses_relative_units": UsesRelativeUnits(),
-            "check_media_queries": CheckMediaQueries(),
-            "check_flexbox_usage": CheckFlexboxUsage(),
-            "check_bootstrap_usage": CheckBootstrapUsage(),
-            "link_points_to_page_with_query_param": LinkPointsToPageWithQueryParam(),
-            "js_uses_query_string_parsing": JsUsesQueryStringParsing(),
-            "js_has_json_array_with_id": JsHasJsonArrayWithId(),
-            "js_uses_dom_manipulation": JsUsesDomManipulation(),
-            "has_no_js_framework": HasNoJsFramework()
+            "Has Class": HasClass(),
+            "Check Bootstrap Linked": CheckBootstrapLinked(),
+            "Check Internal Links": CheckInternalLinks(),
+            "Has Tag": HasTag(),
+            "Has Forbidden Tag": HasForbiddenTag(),
+            "Has Attribute": HasAttribute(),
+            "Check no Unclosed Tags": CheckNoUnclosedTags(),
+            "Check no Inline Styles": CheckNoInlineStyles(),
+            "Uses Semantic Tags": UsesSemanticTags(),
+            "Check CSS Linked": CheckCssLinked(),
+            "CSS Uses Property": CssUsesProperty(),
+            "Count Over Usage": CountOverUsage(),
+            "JS Uses Feature": JsUsesFeature(),
+            "Uses Forbidden Method": UsesForbiddenMethod(),
+            "Count Global Vars": CountGlobalVars(),
+            "Check Headings Sequential": CheckHeadingsSequential(),
+            "Check all Images Have alt": CheckAllImagesHaveAlt(),
+            "Check HTML Direct Children": CheckHtmlDirectChildren(),
+            "Check Tag not Inside": CheckTagNotInside(),
+            "Check Internal Links to Article": CheckInternalLinksToArticle(),
+            "Has Style": HasStyle(),
+            "Check Head Details": CheckHeadDetails(),
+            "Check Attribute and Value": CheckAttributeAndValue(),
+            "Check dir Exists": CheckDirExists(),
+            "Check Project Structure": CheckProjectStructure(),
+            "Check ID Selector Over Usage": CheckIdSelectorOverUsage(),
+            "Uses Relative Units": UsesRelativeUnits(),
+            "Check Media Queries": CheckMediaQueries(),
+            "Check Flexbox Usage": CheckFlexboxUsage(),
+            "Check Bootstrap Usage": CheckBootstrapUsage(),
+            "Link Points to Page with Query Param": LinkPointsToPageWithQueryParam(),
+            "JS Uses Query String Parsing": JsUsesQueryStringParsing(),
+            "JS Has JSON Array with ID": JsHasJsonArrayWithId(),
+            "JS Uses Dom Manipulation": JsUsesDomManipulation(),
+            "Has no JS Framework": HasNoJsFramework()
         }
 
     def stop(self):

--- a/tests/playroom/api_playroom.py
+++ b/tests/playroom/api_playroom.py
@@ -115,7 +115,7 @@ def create_criteria_config():
                             "weight": 30,
                             "tests": [
                                 {
-                                    "name": "health_check",
+                                    "name": "Health Check",
                                     "calls": [
                                         ["/health"]
                                     ]
@@ -126,7 +126,7 @@ def create_criteria_config():
                             "weight": 35,
                             "tests": [
                                 {
-                                    "name": "check_response_json",
+                                    "name": "Check Response JSON",
                                     "calls": [
                                         ["/api/users", "0", {"id": 1}]
                                     ]
@@ -137,7 +137,7 @@ def create_criteria_config():
                             "weight": 35,
                             "tests": [
                                 {
-                                    "name": "check_response_json",
+                                    "name": "Check Response JSON",
                                     "calls": [
                                         ["/api/users/1", "id", 1],
                                         ["/api/users/1", "name", "Alice"]
@@ -156,7 +156,7 @@ def create_criteria_config():
                     "weight": 100,
                     "tests": [
                         {
-                            "name": "check_response_json",
+                            "name": "Check Response JSON",
                             "calls": [
                                 ["/api/users/2", "email", "bob@example.com"]
                             ]

--- a/tests/playroom/essay_playroom.py
+++ b/tests/playroom/essay_playroom.py
@@ -100,7 +100,7 @@ def create_criteria_config():
                             "tests": [
                                 {
                                     "file": "essay.txt",
-                                    "name": "clarity_and_cohesion"
+                                    "name": "Clarity and Cohesion"
                                 }
                             ]
                         },
@@ -109,7 +109,7 @@ def create_criteria_config():
                             "tests": [
                                 {
                                     "file": "essay.txt",
-                                    "name": "grammar_and_spelling"
+                                    "name": "Grammar and Spelling"
                                 }
                             ]
                         }
@@ -123,7 +123,7 @@ def create_criteria_config():
                             "tests": [
                                 {
                                     "file": "essay.txt",
-                                    "name": "thesis_statement"
+                                    "name": "Thesis Statement"
                                 }
                             ]
                         },
@@ -132,7 +132,7 @@ def create_criteria_config():
                             "tests": [
                                 {
                                     "file": "essay.txt",
-                                    "name": "argument_strength"
+                                    "name": "Argument Strength"
                                 }
                             ]
                         },
@@ -141,7 +141,7 @@ def create_criteria_config():
                             "tests": [
                                 {
                                     "file": "essay.txt",
-                                    "name": "adherence_to_prompt",
+                                    "name": "Adherence to Prompt",
                                     "calls": [
                                         ["Discuss the impact of artificial intelligence on modern education, including both benefits and challenges"]
                                     ]
@@ -163,7 +163,7 @@ def create_criteria_config():
                             "tests": [
                                 {
                                     "file": "essay.txt",
-                                    "name": "counterargument_handling"
+                                    "name": "Counterargument Handling"
                                 }
                             ]
                         },
@@ -172,7 +172,7 @@ def create_criteria_config():
                             "tests": [
                                 {
                                     "file": "essay.txt",
-                                    "name": "evidence_quality"
+                                    "name": "Evidence Quality"
                                 }
                             ]
                         }
@@ -188,7 +188,7 @@ def create_criteria_config():
                     "tests": [
                         {
                             "file": "essay.txt",
-                            "name": "logical_fallacy_check"
+                            "name": "Logical Fallacy Check"
                         }
                     ]
                 }

--- a/tests/playroom/io_playroom.py
+++ b/tests/playroom/io_playroom.py
@@ -85,7 +85,7 @@ def create_criteria_config():
                             "weight": 25,
                             "tests": [
                                 {
-                                    "name": "expect_output",
+                                    "name": "Expect Output",
                                     "calls": [
                                         [["10", "+", "5"], "Result: 15.0"]
                                     ]
@@ -96,7 +96,7 @@ def create_criteria_config():
                             "weight": 25,
                             "tests": [
                                 {
-                                    "name": "expect_output",
+                                    "name": "Expect Output",
                                     "calls": [
                                         [["20", "-", "8"], "Result: 12.0"]
                                     ]
@@ -107,7 +107,7 @@ def create_criteria_config():
                             "weight": 25,
                             "tests": [
                                 {
-                                    "name": "expect_output",
+                                    "name": "Expect Output",
                                     "calls": [
                                         [["6", "*", "7"], "Result: 42.0"]
                                     ]
@@ -118,7 +118,7 @@ def create_criteria_config():
                             "weight": 25,
                             "tests": [
                                 {
-                                    "name": "expect_output",
+                                    "name": "Expect Output",
                                     "calls": [
                                         [["100", "/", "4"], "Result: 25.0"]
                                     ]
@@ -136,7 +136,7 @@ def create_criteria_config():
                     "weight": 100,
                     "tests": [
                         {
-                            "name": "expect_output",
+                            "name": "Expect Output",
                             "calls": [
                                 [["10", "/", "0"], "Error: Division by zero"]
                             ]

--- a/tests/playroom/webdev_playroom.py
+++ b/tests/playroom/webdev_playroom.py
@@ -94,7 +94,7 @@ def create_criteria_config():
                             "tests": [
                                 {
                                     "file": "index.html",
-                                    "name": "check_bootstrap_linked"
+                                    "name": "Check Bootstrap Linked"
                                 }
                             ]
                         },
@@ -103,7 +103,7 @@ def create_criteria_config():
                             "tests": [
                                 {
                                     "file": "index.html",
-                                    "name": "has_class",
+                                    "name": "Has Class",
                                     "calls": [
                                         [["col-*"], 3]
                                     ]
@@ -120,7 +120,7 @@ def create_criteria_config():
                             "tests": [
                                 {
                                     "file": "index.html",
-                                    "name": "has_class",
+                                    "name": "Has Class",
                                     "calls": [
                                         [["card", "card-body"], 6]
                                     ]
@@ -132,7 +132,7 @@ def create_criteria_config():
                             "tests": [
                                 {
                                     "file": "index.html",
-                                    "name": "has_class",
+                                    "name": "Has Class",
                                     "calls": [
                                         [["custom-*"], 2]
                                     ]
@@ -151,7 +151,7 @@ def create_criteria_config():
                     "tests": [
                         {
                             "file": "index.html",
-                            "name": "check_no_inline_styles"
+                            "name": "Check no Inline Styles"
                         }
                     ]
                 }


### PR DESCRIPTION
Updated test names and calls to ensure proper output formatting
Example: ```has_class```->```Has Class```
I also took the liberty of updating some formatting, like changing 'css' to 'CSS', 'html' to 'HTML', etc.