### PR TITLE
refactor(logging): replace print statements with structured logging and remove emojis

### DIFF
--- a/autograder/autograder_facade.py
+++ b/autograder/autograder_facade.py
@@ -403,13 +403,13 @@ if __name__ == "__main__":
 
         # 8. Print the results
         logger.info("--- Grading Complete ---")
-        print(f"Status: {facade_response.status}")
-        print(f"Final Score: {facade_response.final_score}")
-        print("\n--- Feedback ---")
-        print(facade_response.feedback)
-        print("\n--- Test Report ---")
+        logger.info(f"Status: {facade_response.status}")
+        logger.info(f"Final Score: {facade_response.final_score}")
+        logger.info("\n--- Feedback ---")
+        logger.info(facade_response.feedback)
+        logger.info("\n--- Test Report ---")
         if facade_response.test_report:
             for test in facade_response.test_report:
-                print(f"- {test.subject_name}: {test.test_name} -> Score: {test.score}, Report: {test.report}")
+                logger.info(f"- {test.subject_name}: {test.test_name} -> Score: {test.score}, Report: {test.report}")
         else:
-            print("No test report generated.")
+            logger.info("No test report generated.")

--- a/autograder/builder/models/criteria_tree.py
+++ b/autograder/builder/models/criteria_tree.py
@@ -1,7 +1,10 @@
+import logging
 from typing import List, Any, Dict
 from autograder.context import request_context
 from autograder.core.models.test_result import TestResult
 
+
+logger = logging.getLogger(__name__)
 
 # Assuming TestResult is defined in a separate, importable file
 # from autograder.core.models.test_result import TestResult
@@ -127,7 +130,7 @@ class Criteria:
 
     def print_tree(self):
         """Prints a visual representation of the entire criteria tree."""
-        print(f"🌲 Criteria Tree")
+        logger.info("Criteria Tree")
         self._print_category(self.base, prefix="  ")
         self._print_category(self.bonus, prefix="  ")
         self._print_category(self.penalty, prefix="  ")
@@ -144,9 +147,9 @@ class Criteria:
         
         if category.tests:
             for test in category.tests:
-                print(f"{prefix}    - 🧪 {test.name} (file: {test.file})")
+                logger.info(f"    - {test.name} (file: {test.file})")
                 if test.parameters:
-                    print(f"{prefix}      - Parameters: {test.parameters}")
+                    logger.info(f"      - Parameters: {test.parameters}")
 
     def _print_subject(self, subject: Subject, prefix: str):
         """Recursive helper method to print a subject and its contents."""
@@ -158,13 +161,13 @@ class Criteria:
 
         if subject.tests is not None:
             for test in subject.tests:
-                print(f"{prefix}  - 🧪 {test.name} (file: {test.file})")
+                logger.info(f"  - {test.name} (file: {test.file})")
                 if test.parameters:
-                    print(f"{prefix}    - Parameters: {test.parameters}")
+                    logger.info(f"    - Parameters: {test.parameters}")
 
     def print_pre_executed_tree(self):
         """Prints a visual representation of the entire pre-executed criteria tree."""
-        print(f"🌲 Pre-Executed Criteria Tree")
+        logger.info("Pre-Executed Criteria Tree")
         self._print_pre_executed_category(self.base, prefix="  ")
         self._print_pre_executed_category(self.bonus, prefix="  ")
         self._print_pre_executed_category(self.penalty, prefix="  ")
@@ -184,9 +187,9 @@ class Criteria:
             for result in category.tests:
                 if isinstance(result, TestResult):
                     params_str = f" (Parameters: {result.parameters})" if result.parameters else ""
-                    print(f"{prefix}    - 📝 {result.test_name}{params_str} -> Score: {result.score}")
+                    logger.info(f"    - {result.test_name}{params_str} -> Score: {result.score}")
                 else:
-                    print(f"{prefix}    - ? Unexpected item in tests list: {result}")
+                    logger.info(f"    - Unexpected item in tests list: {result}")
 
     def _print_pre_executed_subject(self, subject: Subject, prefix: str):
         """Recursive helper method to print a subject and its pre-executed test results."""
@@ -203,16 +206,16 @@ class Criteria:
             for result in subject.tests:
                 if isinstance(result, TestResult):
                     params_str = f" (Parameters: {result.parameters})" if result.parameters else ""
-                    print(f"{prefix}  - 📝 {result.test_name}{params_str} -> Score: {result.score}")
+                    logger.info(f"  - {result.test_name}{params_str} -> Score: {result.score}")
 
                 elif isinstance(result, Test):
-                    print(f"{prefix} - 🧪 {result.name} (file: {result.file})")
+                    logger.info(f" - {result.name} (file: {result.file})")
                     """Added the symbol identificator to match the previous formatting"""
                     if result.parameters:
-                        print(f"{prefix}    - Parameters: {result.parameters}")
+                        logger.info(f"    - Parameters: {result.parameters}")
                 else:
                     # Fallback for unexpected types
-                    print(f"{prefix}  - ? Unexpected item in tests list: {result}")
+                    logger.info(f"  - Unexpected item in tests list: {result}")
 
 
 

--- a/autograder/core/execution/proxy.py
+++ b/autograder/core/execution/proxy.py
@@ -1,3 +1,5 @@
+import logging
+
 class LazyExecutorProxy:
     def __init__(self, executor_cls, *args, **kwargs):
         self._executor_cls = executor_cls
@@ -8,7 +10,8 @@ class LazyExecutorProxy:
     def _ensure_started(self):
         """Initializes the real executor only on first use."""
         if self._instance is None:
-            print(f"[{self._executor_cls.__name__}] Lazy start triggered...")
+            logger = logging.getLogger(__name__)
+            logger.debug(f"[{self._executor_cls.__name__}] Lazy start triggered...")
             self._instance = self._executor_cls.start(*self._args, **self._kwargs)
         return self._instance
 

--- a/autograder/core/report/fatal_report.py
+++ b/autograder/core/report/fatal_report.py
@@ -1,5 +1,8 @@
 import os
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 
@@ -37,7 +40,7 @@ class FatalReporter:
         """
         # If no specific path is provided, construct the default path
         if report_path is None:
-            print(FatalReporter.RESULTS_DIR)
+            logger.debug(f"Results directory: {FatalReporter.RESULTS_DIR}")
             report_path = os.path.join(FatalReporter.RESULTS_DIR, 'fatal_report.json')
 
         # --- Read and Validate Report File ---
@@ -45,13 +48,13 @@ class FatalReporter:
             with open(report_path, 'r', encoding='utf-8') as f:
                 data = json.load(f)
         except FileNotFoundError:
-            return "## ❌ Error\nCould not find the fatal error report file. Please contact an administrator."
+            return "## Error\nCould not find the fatal error report file. Please contact an administrator."
         except json.JSONDecodeError:
-            return "## ❌ Error\nCould not parse the fatal error report file due to a syntax error. Please contact an administrator."
+            return "## Error\nCould not parse the fatal error report file due to a syntax error. Please contact an administrator."
 
         errors = data.get("errors", [])
         if not errors:
-            return "## ✅ No Fatal Errors Found\nYour submission passed all initial checks."
+            return "## No Fatal Errors Found\nYour submission passed all initial checks."
 
         # --- Group Errors for Structured Reporting ---
         grouped_errors = {}
@@ -62,14 +65,14 @@ class FatalReporter:
             grouped_errors[error_type].append(error.get("message", "No message provided."))
 
         # --- Build the Markdown Report ---
-        markdown_report = ["# 🚨 Autograder Fatal Error Report\n"]
+        markdown_report = ["# Autograder Fatal Error Report\n"]
         markdown_report.append(
             "We're sorry, but the autograder could not run due to the following critical issues with your submission. Please fix them and resubmit.\n")
 
         # Handle specific, common error types with custom formatting
         if "file_check" in grouped_errors:
             markdown_report.append("---")
-            markdown_report.append("## 📁 Missing Files")
+            markdown_report.append("## Missing Files")
             markdown_report.append(
                 "The following required files were not found. Please ensure they are named correctly and are located in the root directory of your project.\n")
             for msg in grouped_errors.pop("file_check"):
@@ -85,7 +88,7 @@ class FatalReporter:
         for error_type, messages in grouped_errors.items():
             markdown_report.append("---")
             heading = error_type.replace('_', ' ').title()
-            markdown_report.append(f"## ❗ {heading}")
+            markdown_report.append(f"## {heading}")
             for msg in messages:
                 markdown_report.append(f"- {msg}")
             markdown_report.append("\n")
@@ -112,5 +115,5 @@ class FatalReporter:
 if __name__ == "__main__":
     # Example usage
     report = FatalReporter.generate_feedback()
-    print(report)
+    logger.info(report)
     # Note: In a real scenario, you would call FatalReporter.create(result) to create the initial report file.

--- a/connectors/adapters/github_action_adapter/github_entrypoint.py
+++ b/connectors/adapters/github_action_adapter/github_entrypoint.py
@@ -1,6 +1,10 @@
+import logging
 from argparse import ArgumentParser
 from connectors.adapters.github_action_adapter.github_adapter import GithubAdapter
 from connectors.models.assignment_config import AssignmentConfig
+
+logger = logging.getLogger(__name__)
+
 parser = ArgumentParser(description="GitHub Action Adapter for Autograder")
 parser.add_argument("--github-token", type=str, required=True, help="GitHub Token")
 parser.add_argument("--template-preset", type=str, required=True, help="The grading preset to use (e.g., api, html, python, etc.)")
@@ -34,7 +38,7 @@ async def main():
         pass
     else:
         assignment_config = adapter.create_assigment_config(template_preset)
-        print(assignment_config)
+        logger.info(f"Assignment config created: {assignment_config}")
 
     # Parse include_feedback value
     include_feedback = False
@@ -58,10 +62,11 @@ async def main():
 
     adapter.run_autograder()
 
-    print(f"Final Score for {student_name}: {adapter.autograder_response.final_score}")
+    logger.info(f"Final Score for {student_name}: {adapter.autograder_response.final_score}")
 
     adapter.export_results()
 
 if __name__ == "__main__":
     import asyncio
+    logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
     asyncio.run(main())


### PR DESCRIPTION
## Description
This PR addresses issue #158 by refactoring the codebase to use proper structured logging instead of raw [print](cci:1://file:///c:/Users/samue/Documents/GitHub/autograder/autograder/builder/models/criteria_tree.py:130:4-135:55) statements. It also "humanizes" the output by removing emojis and non-professional icons, ensuring a cleaner and more maintainable debugging experience.

## Fixes
Fixes #158

## Changes Made
- **Logging Refactor**: 
    - [grader.py](cci:7://file:///c:/Users/samue/Documents/GitHub/autograder/autograder/core/grading/grader.py:0:0-0:0): Switched to `logger.info()` for grading milestones and `logger.debug()` for per-test results.
    - [criteria_tree.py](cci:7://file:///c:/Users/samue/Documents/GitHub/autograder/autograder/builder/models/criteria_tree.py:0:0-0:0): Replaced visualization prints with structured logs.
    - [proxy.py](cci:7://file:///c:/Users/samue/Documents/GitHub/autograder/autograder/core/execution/proxy.py:0:0-0:0) & [fatal_report.py](cci:7://file:///c:/Users/samue/Documents/GitHub/autograder/autograder/core/report/fatal_report.py:0:0-0:0): Integrated lazy logging and internal resolution tracking.
- **Code Humanization**:
    - Removed all emojis (🌲, 📁, 📘, 🧪, 🚨, etc.) from log messages and markdown feedback results.
- **Entrypoint Standardization**:
    - Configured `logging.basicConfig` in [github_entrypoint.py](cci:7://file:///c:/Users/samue/Documents/GitHub/autograder/connectors/adapters/github_action_adapter/github_entrypoint.py:0:0-0:0) and [autograder_facade.py](cci:7://file:///c:/Users/samue/Documents/GitHub/autograder/autograder/autograder_facade.py:0:0-0:0) for consistent CLI behavior.

## Impact
- Users will now see cleaner, more professional CLI output.
- Developers can use the `--debug` (or equivalent) log level to see detailed information without it cluttering production runs.
- Resolved potential encoding issues by removing non-ASCII emojis from stdout.

## Verification
- Successfully ran `python -m autograder.autograder_facade` to confirm output formatting.
- Verified that dependencies in [requirements.txt](cci:7://file:///c:/Users/samue/Documents/GitHub/autograder/requirements.txt:0:0-0:0) are correctly handled.