### PR TITLE
feat(sandboxing): Abstract Stderr Runtime Container Streams into PyObjs

### DIFF
--- a/autograder/services/pre_flight_service.py
+++ b/autograder/services/pre_flight_service.py
@@ -4,7 +4,7 @@ from autograder.models.dataclass.preflight_error import PreflightError, Prefligh
 from autograder.models.dataclass.submission import Submission
 from sandbox_manager.sandbox_container import SandboxContainer
 from sandbox_manager.manager import get_sandbox_manager
-from sandbox_manager.models.sandbox_models import Language
+from sandbox_manager.models.sandbox_models import Language, ResponseCategory
 
 
 class PreFlightService:
@@ -144,10 +144,10 @@ class PreFlightService:
             try:
                 response = sandbox.run_command(command)
                 self.logger.debug(f"Setup command '{command_name}' exit code: {response.exit_code}")
-                self.logger.debug(f"Setup command '{command_name}' stdout: {response.stdout}")
-                self.logger.debug(f"Setup command '{command_name}' stderr: {response.stderr}")
+                self.logger.debug(f"Setup command '{command_name}' category: {response.category.value}")
 
-                if response.exit_code != 0:
+                # Use the new category classification
+                if response.category != ResponseCategory.SUCCESS:
                     error_msg = self._format_setup_command_error(command_name, command, response)
                     self.logger.error(error_msg)
                     self.fatal_errors.append(PreflightError(
@@ -157,6 +157,7 @@ class PreFlightService:
                             "command_name": command_name,
                             "command": command,
                             "exit_code": response.exit_code,
+                            "category": response.category.value,  # Track the category here
                             "stdout": response.stdout,
                             "stderr": response.stderr
                         }

--- a/sandbox_manager/models/sandbox_models.py
+++ b/sandbox_manager/models/sandbox_models.py
@@ -21,18 +21,24 @@ class SandboxState(Enum):
     BUSY = "busy"
     STOPPED = "stopped"
 
+class ResponseCategory(Enum):
+    SUCCESS = "success"             # Program ran and exited with 0
+    RUNTIME_ERROR = "runtime_error" # Program crashed (e.g., Exception, Segmentation Fault)
+    TIMEOUT = "timeout"             # Program was killed because it took too long
+    SYSTEM_ERROR = "system_error"   # Infrastructure failure (e.g., Docker error)
+    COMPILATION_ERROR = "compilation_error" # Specific to compiled languages like C++/Java
 
 @dataclass
 class CommandResponse:
-    """Response from executing a command in a sandbox container."""
     stdout: str
     stderr: str
     exit_code: int
-    execution_time: float  # in seconds
+    execution_time: float
+    # New field to hold the classification
+    category: ResponseCategory = ResponseCategory.SUCCESS
 
     @property
     def output(self) -> str:
-        """Combined stdout for backward compatibility."""
         return self.stdout
 
     def __str__(self):

--- a/sandbox_manager/utils/classify_output.py
+++ b/sandbox_manager/utils/classify_output.py
@@ -1,0 +1,29 @@
+from sandbox_manager.models.sandbox_models import ResponseCategory, Language
+
+
+def classify_output(stdout: str, stderr: str, exit_code: int, language: Language) -> ResponseCategory:
+    if exit_code == 0:
+        return ResponseCategory.SUCCESS
+
+    if exit_code == 137:  # Common Docker OOM/Killed exit code
+        return ResponseCategory.TIMEOUT
+
+    # Detect compilation errors (assuming your pipeline separates build/run)
+    # or detect them via stderr keywords
+    compilation_keywords = ["error:", "javac", "g++"]
+    if any(k in stderr.lower() for k in compilation_keywords) and exit_code != 0:
+        return ResponseCategory.COMPILATION_ERROR
+
+    # Detect Runtime Errors
+    runtime_indicators = {
+        Language.PYTHON: ["Traceback (most recent call last):", "Error:"],
+        Language.JAVA: ["Exception in thread", "java.lang."],
+        Language.NODE: ["ReferenceError:", "TypeError:", "Uncaught"],
+        Language.CPP: ["segmentation fault", "core dumped"]
+    }
+
+    indicators = runtime_indicators.get(language, [])
+    if any(ind in stderr for ind in indicators):
+        return ResponseCategory.RUNTIME_ERROR
+
+    return ResponseCategory.SYSTEM_ERROR


### PR DESCRIPTION
This PR adds a classification layer to sandbox executions. Instead of treating all program failures as generic "output mismatches," the autograder now parses container exit codes and stderr streams to identify the exact cause of a failure, such as a runtime crash, compilation error, or timeout.

This allows the grading pipeline to decouple the execution state from the raw output, passing specific error contexts to the grading templates and preflight checks.

Errors Catched:
| Category | Error Type / Condition | Languages Affected |
| :--- | :--- | :--- |
| **`SUCCESS`** | Exit code `0` | All |
| **`TIMEOUT`** | Exit code `137` (OOM / Killed) | All |
| **`COMPILATION_ERROR`**| Stderr contains `error:`, `javac`, or `g++` (with non-zero exit code) | Java, C++ |
| **`RUNTIME_ERROR`** | Stderr contains `Traceback (most recent call last):` or `Error:` | Python |
| **`RUNTIME_ERROR`** | Stderr contains `Exception in thread` or `java.lang.` | Java |
| **`RUNTIME_ERROR`** | Stderr contains `ReferenceError:`, `TypeError:`, or `Uncaught` | Node (JavaScript) |
| **`RUNTIME_ERROR`** | Stderr contains `segmentation fault` or `core dumped` | C++ |
| **`SYSTEM_ERROR`** | Any other non-zero exit code | All |