### PR TITLE
feat: Implement C runner 

### DIFF
--- a/autograder/services/command_resolver.py
+++ b/autograder/services/command_resolver.py
@@ -17,7 +17,8 @@ class CommandResolver:
         Language.PYTHON: "python3 {filename}",
         Language.JAVA: "java {classname}",
         Language.NODE: "node {filename}",
-        Language.CPP: "./{executable}"
+        Language.CPP: "./{executable}",
+        Language.C: "./{executable}"
     }
 
     def __init__(self):
@@ -129,6 +130,13 @@ class CommandResolver:
             # C++ executables are typically compiled to a specific name
             if fallback_filename and fallback_filename.endswith('.cpp'):
                 executable = fallback_filename[:-4]  # Remove .cpp
+                return f"./{executable}"
+            return "./a.out"
+
+        elif language == Language.C:
+            # C executables follow the same pattern as C++
+            if fallback_filename and fallback_filename.endswith('.c'):
+                executable = fallback_filename[:-2]  # Remove .c
                 return f"./{executable}"
             return "./a.out"
 

--- a/sandbox_manager/models/sandbox_models.py
+++ b/sandbox_manager/models/sandbox_models.py
@@ -9,6 +9,7 @@ class Language(Enum):
     JAVA = ("java", "sandbox-java:latest")
     NODE = ("node", "sandbox-node:latest")
     CPP = ("cpp", "sandbox-cpp:latest")
+    C = ("c", "sandbox-cpp:latest")
 
     def __new__(cls, value, image):
         obj = object.__new__(cls)

--- a/sandbox_manager/utils/classify_output.py
+++ b/sandbox_manager/utils/classify_output.py
@@ -10,7 +10,7 @@ def classify_output(stdout: str, stderr: str, exit_code: int, language: Language
 
     # Detect compilation errors (assuming your pipeline separates build/run)
     # or detect them via stderr keywords
-    compilation_keywords = ["error:", "javac", "g++"]
+    compilation_keywords = ["error:", "javac", "g++", "gcc"]
     if any(k in stderr.lower() for k in compilation_keywords) and exit_code != 0:
         return ResponseCategory.COMPILATION_ERROR
 
@@ -19,7 +19,8 @@ def classify_output(stdout: str, stderr: str, exit_code: int, language: Language
         Language.PYTHON: ["Traceback (most recent call last):", "Error:"],
         Language.JAVA: ["Exception in thread", "java.lang."],
         Language.NODE: ["ReferenceError:", "TypeError:", "Uncaught"],
-        Language.CPP: ["segmentation fault", "core dumped"]
+        Language.CPP: ["segmentation fault", "core dumped"],
+        Language.C: ["segmentation fault", "core dumped"]
     }
 
     indicators = runtime_indicators.get(language, [])

--- a/tests/integration/test_execution_endpoint.py
+++ b/tests/integration/test_execution_endpoint.py
@@ -177,9 +177,41 @@ int main() {
     print("✓ Test passed!")
 
 
+def test_c_execution():
+    """Test C code execution."""
+    print("\n=== Test 7: C Execution ===")
+
+    request = {
+        "language": "c",
+        "submission_files": [
+            {
+                "filename": "main.c",
+                "content": """
+#include <stdio.h>
+
+int main() {
+    printf("Hello from C!\\n");
+    return 0;
+}
+"""
+            }
+        ],
+        "program_command": "gcc main.c -o main && ./main"
+    }
+
+    response = requests.post(f"{BASE_URL}/execute", json=request)
+    print(f"Status: {response.status_code}")
+    print(f"Response: {json.dumps(response.json(), indent=2)}")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "Hello from C!" in data["output"]
+    print("✓ Test passed!")
+
+
 def test_multiple_files():
     """Test execution with multiple files."""
-    print("\n=== Test 7: Multiple Files ===")
+    print("\n=== Test 8: Multiple Files ===")
 
     request = {
         "language": "python",
@@ -208,7 +240,7 @@ def test_multiple_files():
 
 def test_invalid_language():
     """Test with invalid language."""
-    print("\n=== Test 8: Invalid Language ===")
+    print("\n=== Test 9: Invalid Language ===")
 
     request = {
         "language": "rust",  # Not supported
@@ -240,6 +272,7 @@ if __name__ == "__main__":
         test_java_execution()
         test_node_execution()
         test_cpp_execution()
+        test_c_execution()
         test_multiple_files()
         test_invalid_language()
 

--- a/tests/unit/test_command_resolver.py
+++ b/tests/unit/test_command_resolver.py
@@ -68,6 +68,19 @@ class TestCommandResolver:
         result = self.resolver.resolve_command(commands, Language.CPP)
         assert result == "./calculator"
 
+    def test_resolve_multi_language_dict_c(self):
+        """Test resolving multi-language dict format for C."""
+        commands = {
+            "python": "python3 calculator.py",
+            "java": "java Calculator",
+            "node": "node calculator.js",
+            "cpp": "./calculator",
+            "c": "./calculator"
+        }
+
+        result = self.resolver.resolve_command(commands, Language.C)
+        assert result == "./calculator"
+
     def test_resolve_cmd_placeholder_python(self):
         """Test auto-resolution with CMD placeholder for Python."""
         result = self.resolver.resolve_command("CMD", Language.PYTHON)
@@ -86,6 +99,11 @@ class TestCommandResolver:
     def test_resolve_cmd_placeholder_cpp(self):
         """Test auto-resolution with CMD placeholder for C++."""
         result = self.resolver.resolve_command("CMD", Language.CPP)
+        assert result == "./a.out"
+
+    def test_resolve_cmd_placeholder_c(self):
+        """Test auto-resolution with CMD placeholder for C."""
+        result = self.resolver.resolve_command("CMD", Language.C)
         assert result == "./a.out"
 
     def test_resolve_none_command(self):
@@ -137,6 +155,15 @@ class TestCommandResolver:
             "CMD",
             Language.CPP,
             fallback_filename="calculator.cpp"
+        )
+        assert result == "./calculator"
+
+    def test_resolve_with_fallback_filename_c(self):
+        """Test auto-resolution with fallback filename for C."""
+        result = self.resolver.resolve_command(
+            "CMD",
+            Language.C,
+            fallback_filename="calculator.c"
         )
         assert result == "./calculator"
 
@@ -195,6 +222,7 @@ class TestCommandResolver:
         # Should return None for unspecified languages
         assert self.resolver.resolve_command(commands, Language.NODE) is None
         assert self.resolver.resolve_command(commands, Language.CPP) is None
+        assert self.resolver.resolve_command(commands, Language.C) is None
 
     def test_resolve_empty_dict(self):
         """Test that empty dict returns None."""

--- a/tests/unit/test_language_validation.py
+++ b/tests/unit/test_language_validation.py
@@ -12,7 +12,7 @@ class TestLanguageValidation:
 
     def test_grading_config_create_valid_languages(self):
         """Test that valid languages are accepted in GradingConfigCreate."""
-        valid_languages = ["python", "java", "node", "cpp", "PYTHON", "Java", "NODE", "Cpp"]
+        valid_languages = ["python", "java", "node", "cpp", "c", "PYTHON", "Java", "NODE", "Cpp", "C"]
 
         for lang in valid_languages:
             config = GradingConfigCreate(
@@ -22,7 +22,7 @@ class TestLanguageValidation:
                 languages=[lang]
             )
             # Should normalize to lowercase
-            assert config.languages[0] in ["python", "java", "node", "cpp"]
+            assert config.languages[0] in ["python", "java", "node", "cpp", "c"]
 
     def test_grading_config_create_invalid_language(self):
         """Test that invalid languages are rejected in GradingConfigCreate."""
@@ -55,7 +55,7 @@ class TestLanguageValidation:
 
     def test_grading_config_create_unsupported_languages(self):
         """Test that various unsupported languages are rejected."""
-        unsupported = ["ruby", "go", "rust", "c", "csharp", "php", "perl"]
+        unsupported = ["ruby", "go", "rust", "csharp", "php", "perl"]
 
         for lang in unsupported:
             with pytest.raises(ValidationError) as exc_info:


### PR DESCRIPTION
This pull request adds support for the C programming language throughout the autograder and sandbox manager systems. The changes ensure that C submissions are properly recognized, executed, and classified, and that tests are in place to validate the new functionality.

**C Language Support**

* Added `Language.C` to the `Language` enum in `sandbox_manager/models/sandbox_models.py`, reusing the same sandbox image as C++ for execution.
* Updated `CommandResolver` in `autograder/services/command_resolver.py` to handle C programs, providing the correct execution command and auto-resolution logic for C files. [[1]](diffhunk://#diff-518e1dc001d2ceb6c2734dfb42382a32d9380ad8878e26d3ab98abbd3518ccc8L20-R21) [[2]](diffhunk://#diff-518e1dc001d2ceb6c2734dfb42382a32d9380ad8878e26d3ab98abbd3518ccc8R136-R142)

**Output Classification**

* Enhanced output classification for C by adding `"gcc"` to the compilation error keywords and runtime error indicators for C in `sandbox_manager/utils/classify_output.py`. [[1]](diffhunk://#diff-5f92419a1ced18e538768d46bcb53d772df0f2ba89b4f38a93e0d5b067fd0a5cL13-R13) [[2]](diffhunk://#diff-5f92419a1ced18e538768d46bcb53d772df0f2ba89b4f38a93e0d5b067fd0a5cL22-R23)

**Testing**

* Added an integration test for C code execution in `tests/integration/test_execution_endpoint.py`, ensuring C submissions are executed and output is validated. [[1]](diffhunk://#diff-5b218b5a1e911086566ab659b262d236a101bd6998ce040ec14924a3f8983964R180-R214) [[2]](diffhunk://#diff-5b218b5a1e911086566ab659b262d236a101bd6998ce040ec14924a3f8983964R275)
* Updated unit tests in `tests/unit/test_language_validation.py` to include C as a valid language and removed it from the unsupported list. [[1]](diffhunk://#diff-119115c5dddc55d01e67e5049b392be5ffe75b7a3239b6118ba6011420daeb09L15-R15) [[2]](diffhunk://#diff-119115c5dddc55d01e67e5049b392be5ffe75b7a3239b6118ba6011420daeb09L25-R25) [[3]](diffhunk://#diff-119115c5dddc55d01e67e5049b392be5ffe75b7a3239b6118ba6011420daeb09L58-R58)