### PR TITLE
Fix stdin pipe precedence during execution tests + improvements 

### DIFF
--- a/sandbox_manager/sandbox_container.py
+++ b/sandbox_manager/sandbox_container.py
@@ -177,7 +177,7 @@ class SandboxContainer:
                 # Execute program with stdin piped from echo
                 # This is more reliable than socket-based stdin
                 escaped_input = stdin_input.replace("'", "'\\''")
-                cmd = f"echo '{escaped_input}' | {program_command}"
+                cmd = f"echo '{escaped_input}' | ( {program_command} )"
                 shell_cmd = ["/bin/sh", "-c", cmd]
             else:
                 # Just echo the input (for testing)

--- a/web/api/v1/execution.py
+++ b/web/api/v1/execution.py
@@ -57,7 +57,7 @@ async def execute_code_endpoint(request: DeliberateCodeExecutionRequest):
     try:
         logger.info("Code execution request received for language: %s", request.language)
         result = await execute_code(request)
-        logger.info("Code execution completed with category: %s", result.category)
+        logger.info("Code execution completed with %d result(s)", len(result.results))
         return result
     except ValueError as e:
         logger.warning("Invalid request: %s", e)

--- a/web/schemas/execution.py
+++ b/web/schemas/execution.py
@@ -22,7 +22,7 @@ class DeliberateCodeExecutionRequest(BaseModel):
     language: str = Field(..., description="The programming language of the code to be executed (e.g., python, java, node, cpp).")
     submission_files: List[SubmissionFileData] = Field(..., description="List of files to be executed, including their content.")
     program_command: str = Field(..., description="The command to execute the program (e.g., 'python main.py', 'java Main', 'node app.js', './a.out').")
-    inputs: Optional[List[List[str]]] = Field(None, description="Optional list of inputs to be provided to the code during execution, one input may have multiple arguments.")
+    test_cases: Optional[List[List[str]]] = Field(None, description="Optional list of test cases to be evaluated. Each test case is a list of inputs/arguments.")
 
     @field_validator('language')
     @classmethod
@@ -42,12 +42,19 @@ class DeliberateCodeExecutionRequest(BaseModel):
         return v
 
 
-class DeliberateCodeExecutionResponse(BaseModel):
+class DeliberateCodeExecutionResult(BaseModel):
     """
-    Response schema for Deliberate Code Execution.
+    Result of a single code execution block representing a test case.
     """
     output: str = Field(..., description="The output of the executed code.")
     category: ResponseCategory = Field(..., description="The category of the execution result (e.g., success, runtime_error, timeout, system_error).")
     error_message: Optional[str] = Field(None, description="Any error that occurred during execution.")
     execution_time: float = Field(..., description="Execution time in seconds.")
+
+
+class DeliberateCodeExecutionResponse(BaseModel):
+    """
+    Response schema for Deliberate Code Execution containing all test cases evaluated.
+    """
+    results: List[DeliberateCodeExecutionResult] = Field(..., description="A list of execution results corresponding to each test case.")
 

--- a/web/service/deliberate_execution_service.py
+++ b/web/service/deliberate_execution_service.py
@@ -11,7 +11,7 @@ from autograder.models.dataclass.submission import SubmissionFile
 from sandbox_manager.manager import get_sandbox_manager
 from sandbox_manager.models.sandbox_models import Language, ResponseCategory, CommandResponse
 from web.config.logging import get_logger
-from web.schemas.execution import DeliberateCodeExecutionRequest, DeliberateCodeExecutionResponse
+from web.schemas.execution import DeliberateCodeExecutionRequest, DeliberateCodeExecutionResponse, DeliberateCodeExecutionResult
 
 
 logger = get_logger(__name__)
@@ -101,62 +101,74 @@ async def execute_code(request: DeliberateCodeExecutionRequest) -> DeliberateCod
         sandbox.prepare_workdir(files_dict)
         logger.info("Prepared workdir with %d file(s)", len(files_dict))
 
-        # Execute code
-        result: CommandResponse
+        # Execute test cases
+        execution_results: list[DeliberateCodeExecutionResult] = []
+        
+        # Determine test cases to run (at least 1 empty run if none provided)
+        test_cases = request.test_cases if request.test_cases else [[]]
+        
+        for idx, test_case_args in enumerate(test_cases):
+            logger.info("Executing test case %d of %d", idx + 1, len(test_cases))
+            
+            result: CommandResponse
 
-        if request.inputs:
-            # Flatten inputs if they're provided as list of lists
-            # Each inner list represents arguments for a single input line
-            flattened_inputs = []
-            for input_args in request.inputs:
-                # Join arguments with spaces if multiple args per line
-                flattened_inputs.append(' '.join(input_args) if isinstance(input_args, list) else str(input_args))
+            if test_case_args:
+                # Format/flatten inputs if they're provided as list of lists
+                flattened_inputs = []
+                for input_args in test_case_args:
+                    flattened_inputs.append(str(input_args))
 
-            logger.info("Executing with %d input(s)", len(flattened_inputs))
-            # Use run_commands for interactive input
-            result = await asyncio.to_thread(
-                sandbox.run_commands,
-                flattened_inputs,
-                request.program_command,
-                timeout=30,
-                workdir="/app"
+                logger.info("Executing with %d input(s) for test case %d", len(flattened_inputs), idx + 1)
+                result = await asyncio.to_thread(
+                    sandbox.run_commands,
+                    flattened_inputs,
+                    request.program_command,
+                    timeout=30,
+                    workdir="/app"
+                )
+            else:
+                # No inputs, just run the command
+                logger.info("Executing without inputs for test case %d", idx + 1)
+                result = await asyncio.to_thread(
+                    sandbox.run_command,
+                    request.program_command,
+                    timeout=30,
+                    workdir="/app"
+                )
+
+            logger.info(
+                "Test case %d completed: category=%s, exit_code=%d, time=%.3fs",
+                idx + 1, result.category.value, result.exit_code, result.execution_time
             )
-        else:
-            # No inputs, just run the command
-            logger.info("Executing without inputs")
-            result = await asyncio.to_thread(
-                sandbox.run_command,
-                request.program_command,
-                timeout=30,
-                workdir="/app"
+
+            # Build result item
+            output_parts = [part for part in (result.stdout, result.stderr) if part]
+            output = "\n".join(output_parts)
+            error_message = _get_error_message(result)
+
+            execution_results.append(
+                DeliberateCodeExecutionResult(
+                    output=output,
+                    category=result.category,
+                    error_message=error_message,
+                    execution_time=result.execution_time
+                )
             )
 
-        logger.info(
-            "Execution completed: category=%s, exit_code=%d, time=%.3fs",
-            result.category.value, result.exit_code, result.execution_time
-        )
-
-        # Build response
-        # Combine stdout and stderr so callers see all output (e.g. output before a crash)
-        output_parts = [part for part in (result.stdout, result.stderr) if part]
-        output = "\n".join(output_parts)
-        error_message = _get_error_message(result)
-
-        return DeliberateCodeExecutionResponse(
-            output=output,
-            category=result.category,
-            error_message=error_message,
-            execution_time=result.execution_time
-        )
+        return DeliberateCodeExecutionResponse(results=execution_results)
 
     except Exception as e:  # pylint: disable=broad-exception-caught
         logger.error("Execution failed: %s", e, exc_info=True)
         # Return error response instead of raising
         return DeliberateCodeExecutionResponse(
-            output="",
-            category=ResponseCategory.SYSTEM_ERROR,
-            error_message=f"Execution failed: {str(e)}",
-            execution_time=0.0
+            results=[
+                DeliberateCodeExecutionResult(
+                    output="",
+                    category=ResponseCategory.SYSTEM_ERROR,
+                    error_message=f"Execution failed: {str(e)}",
+                    execution_time=0.0
+                )
+            ]
         )
 
     finally:

--- a/web/service/deliberate_execution_service.py
+++ b/web/service/deliberate_execution_service.py
@@ -50,6 +50,63 @@ def _get_error_message(result: CommandResponse) -> str:
     return error_message
 
 
+async def _execute_test_cases(
+    sandbox,
+    program_command: str,
+    test_cases: list[list[str]]
+) -> list[DeliberateCodeExecutionResult]:
+    """Execute a list of test cases in the sandbox."""
+    execution_results: list[DeliberateCodeExecutionResult] = []
+    
+    for idx, test_case_args in enumerate(test_cases):
+        logger.info("Executing test case %d of %d", idx + 1, len(test_cases))
+        
+        result: CommandResponse
+
+        if test_case_args:
+            # Format/flatten inputs if they're provided as list of lists
+            flattened_inputs = [str(input_args) for input_args in test_case_args]
+
+            logger.info("Executing with %d input(s) for test case %d", len(flattened_inputs), idx + 1)
+            result = await asyncio.to_thread(
+                sandbox.run_commands,
+                flattened_inputs,
+                program_command,
+                timeout=30,
+                workdir="/app"
+            )
+        else:
+            # No inputs, just run the command
+            logger.info("Executing without inputs for test case %d", idx + 1)
+            result = await asyncio.to_thread(
+                sandbox.run_command,
+                program_command,
+                timeout=30,
+                workdir="/app"
+            )
+
+        logger.info(
+            "Test case %d completed: category=%s, exit_code=%d, time=%.3fs",
+            idx + 1, result.category.value, result.exit_code, result.execution_time
+        )
+
+        # Build result item
+        output_parts = [part for part in (result.stdout, result.stderr) if part]
+        output = "\n".join(output_parts)
+        error_message = _get_error_message(result)
+
+        execution_results.append(
+            DeliberateCodeExecutionResult(
+                output=output,
+                category=result.category,
+                error_message=error_message,
+                execution_time=result.execution_time
+            )
+        )
+
+    return execution_results
+
+
 async def execute_code(request: DeliberateCodeExecutionRequest) -> DeliberateCodeExecutionResponse:
     """
     Execute code in a sandbox without grading.
@@ -101,59 +158,15 @@ async def execute_code(request: DeliberateCodeExecutionRequest) -> DeliberateCod
         sandbox.prepare_workdir(files_dict)
         logger.info("Prepared workdir with %d file(s)", len(files_dict))
 
-        # Execute test cases
-        execution_results: list[DeliberateCodeExecutionResult] = []
-        
         # Determine test cases to run (at least 1 empty run if none provided)
         test_cases = request.test_cases if request.test_cases else [[]]
         
-        for idx, test_case_args in enumerate(test_cases):
-            logger.info("Executing test case %d of %d", idx + 1, len(test_cases))
-            
-            result: CommandResponse
-
-            if test_case_args:
-                # Format/flatten inputs if they're provided as list of lists
-                flattened_inputs = []
-                for input_args in test_case_args:
-                    flattened_inputs.append(str(input_args))
-
-                logger.info("Executing with %d input(s) for test case %d", len(flattened_inputs), idx + 1)
-                result = await asyncio.to_thread(
-                    sandbox.run_commands,
-                    flattened_inputs,
-                    request.program_command,
-                    timeout=30,
-                    workdir="/app"
-                )
-            else:
-                # No inputs, just run the command
-                logger.info("Executing without inputs for test case %d", idx + 1)
-                result = await asyncio.to_thread(
-                    sandbox.run_command,
-                    request.program_command,
-                    timeout=30,
-                    workdir="/app"
-                )
-
-            logger.info(
-                "Test case %d completed: category=%s, exit_code=%d, time=%.3fs",
-                idx + 1, result.category.value, result.exit_code, result.execution_time
-            )
-
-            # Build result item
-            output_parts = [part for part in (result.stdout, result.stderr) if part]
-            output = "\n".join(output_parts)
-            error_message = _get_error_message(result)
-
-            execution_results.append(
-                DeliberateCodeExecutionResult(
-                    output=output,
-                    category=result.category,
-                    error_message=error_message,
-                    execution_time=result.execution_time
-                )
-            )
+        # Execute test cases
+        execution_results = await _execute_test_cases(
+            sandbox, 
+            request.program_command, 
+            test_cases
+        )
 
         return DeliberateCodeExecutionResponse(results=execution_results)
 


### PR DESCRIPTION
This pull request refactors the code execution API to support multiple test cases per request and improves the response structure for better clarity and extensibility. The changes include updating the request and response schemas, adding logic to execute multiple test cases, and enhancing logging for execution results.

**API schema changes:**

* Changed the `DeliberateCodeExecutionRequest` schema to use `test_cases` instead of `inputs`, clarifying that each test case is a list of inputs/arguments.
* Refactored the response schema: introduced `DeliberateCodeExecutionResult` for individual test case results and updated `DeliberateCodeExecutionResponse` to return a list of these results.

**Execution logic changes:**

* Added `_execute_test_cases` function to handle execution of multiple test cases, aggregating results for each.
* Updated `execute_code` to run all provided test cases and return a list of results, including improved error handling for failed executions.

**Logging improvements:**

* Modified logging in `execute_code_endpoint` to report the number of results instead of category, reflecting the new multi-test-case response format.

**Sandbox command handling:**

* Improved command execution reliability by wrapping the program command in parentheses when piping input, ensuring correct shell behavior.

**Imports update:**

* Updated imports in `deliberate_execution_service.py` to include new schema classes.