### PR TITLE
[TD][GraderService] Make grading flow stateless (#221)

### DIFF
--- a/autograder/services/grader_service.py
+++ b/autograder/services/grader_service.py
@@ -23,45 +23,40 @@ class GraderService:
 
     def __init__(self):
         self.logger = logging.getLogger("GraderService")
-        self.__submission_files = None
-        self._sandbox = None
-        self._submission_language = None
         self._command_resolver = CommandResolver()
-
-    def set_sandbox(self, sandbox):
-        """Bind a sandbox environment to be used for executing test scenarios."""
-        self._sandbox = sandbox
-
-    def has_sandbox(self) -> bool:
-        """Check if a sandbox environment has been successfully bound to the grader."""
-        return self._sandbox is not None
-
-    def set_submission_language(self, language):
-        """Set the submission language so program_command can be resolved before execution."""
-        self._submission_language = language
 
     def grade_from_tree(
         self,
         criteria_tree: CriteriaTree,
         submission_files: Dict[str, SubmissionFile],
+        sandbox=None,
+        submission_language=None,
     ) -> ResultTree:
         """Traverse the generic built criteria tree to resolve inputs, grades and report to ResultTree."""
-        self.__submission_files = submission_files
-
-        # Create root node with category results
-
-        # Process base category (required)
-        base_result = self.process_category(criteria_tree.base)
+        base_result = self.process_category(
+            criteria_tree.base,
+            submission_files=submission_files,
+            sandbox=sandbox,
+            submission_language=submission_language,
+        )
         root = RootResultNode(name="root", base=base_result)
 
-        # Process bonus category (optional)
         if criteria_tree.bonus:
-            bonus_result = self.process_category(criteria_tree.bonus)
+            bonus_result = self.process_category(
+                criteria_tree.bonus,
+                submission_files=submission_files,
+                sandbox=sandbox,
+                submission_language=submission_language,
+            )
             root.bonus = bonus_result
 
-        # Process penalty category (optional)
         if criteria_tree.penalty:
-            penalty_result = self.process_category(criteria_tree.penalty)
+            penalty_result = self.process_category(
+                criteria_tree.penalty,
+                submission_files=submission_files,
+                sandbox=sandbox,
+                submission_language=submission_language,
+            )
             root.penalty = penalty_result
 
         result_tree = ResultTree(root)
@@ -104,7 +99,11 @@ class GraderService:
     def __process_holder(self, holder: SubjectNode) -> SubjectResultNode: ...
 
     def __process_holder(
-        self, holder: CategoryNode | SubjectNode
+        self,
+        holder: CategoryNode | SubjectNode,
+        submission_files: Dict[str, SubmissionFile],
+        sandbox=None,
+        submission_language=None,
     ) -> CategoryResultNode | SubjectResultNode:
         """Process a category or subject node and create corresponding result node."""
 
@@ -122,14 +121,28 @@ class GraderService:
         subject_results = []
         if holder.subjects:
             subject_results = [
-                self.process_subject(inner_subject) for inner_subject in holder.subjects
+                self.process_subject(
+                    inner_subject,
+                    submission_files=submission_files,
+                    sandbox=sandbox,
+                    submission_language=submission_language,
+                )
+                for inner_subject in holder.subjects
             ]
             self.__balance_nodes(subject_results, subjects_factor)
 
         # Process tests
         test_results = []
         if holder.tests:
-            test_results = [self.process_test(test) for test in holder.tests]
+            test_results = [
+                self.process_test(
+                    test,
+                    submission_files=submission_files,
+                    sandbox=sandbox,
+                    submission_language=submission_language,
+                )
+                for test in holder.tests
+            ]
             self.__balance_nodes(test_results, tests_factor)
 
         # Create appropriate result node type
@@ -149,32 +162,49 @@ class GraderService:
             tests=test_results,
         )
 
-    def process_subject(self, subject: SubjectNode) -> SubjectResultNode:
+    def process_subject(
+        self,
+        subject: SubjectNode,
+        submission_files: Dict[str, SubmissionFile],
+        sandbox=None,
+        submission_language=None,
+    ) -> SubjectResultNode:
         """Process a subject node from criteria tree and create result node."""
-        return self.__process_holder(subject)
+        return self.__process_holder(
+            subject,
+            submission_files=submission_files,
+            sandbox=sandbox,
+            submission_language=submission_language,
+        )
 
-    def process_test(self, test: TestNode) -> TestResultNode:
+    def process_test(
+        self,
+        test: TestNode,
+        submission_files: Optional[Dict[str, SubmissionFile]] = None,
+        sandbox=None,
+        submission_language=None,
+    ) -> TestResultNode:
         """Execute a test and create a test result node.
 
         Resolves `program_command` in-place before calling execute() so that
         test functions always receive a finalized string command.  No hidden
         kwargs are injected; every key in test_params is a declared parameter.
         """
-        file_target = self.get_file_target(test)
+        file_target = self.get_file_target(test, submission_files=submission_files)
 
         # Shallow-copy parameters so we don't mutate the original TestNode.
         test_params = dict(test.parameters or {})
 
         # Resolve program_command eagerly when the language is known.
-        if self._submission_language and 'program_command' in test_params:
+        if submission_language and 'program_command' in test_params:
             raw_command = test_params['program_command']
             resolved = self._command_resolver.resolve_command(
-                raw_command, self._submission_language
+                raw_command, submission_language
             )
             test_params['program_command'] = resolved
 
         test_result = test.test_function.execute(
-            files=file_target, sandbox=self._sandbox, **test_params
+            files=file_target, sandbox=sandbox, **test_params
         )
         return TestResultNode(
             name=test.name,
@@ -184,21 +214,36 @@ class GraderService:
             parameters=test_result.parameters,
         )
 
-    def get_file_target(self, test_node: TestNode) -> Optional[List[SubmissionFile]]:
+    def get_file_target(
+        self,
+        test_node: TestNode,
+        submission_files: Optional[Dict[str, SubmissionFile]],
+    ) -> Optional[List[SubmissionFile]]:
         """Filter out the submission files strictly relevant to the current test node."""
-        if not test_node.file_target or not self.__submission_files:
+        if not test_node.file_target or not submission_files:
             return None
 
         target_files = []
-        for file_name in self.__submission_files:
+        for file_name in submission_files:
             if file_name in test_node.file_target:
-                target_files.append(self.__submission_files[file_name])
+                target_files.append(submission_files[file_name])
 
         return target_files
 
-    def process_category(self, category: CategoryNode) -> CategoryResultNode:
+    def process_category(
+        self,
+        category: CategoryNode,
+        submission_files: Dict[str, SubmissionFile],
+        sandbox=None,
+        submission_language=None,
+    ) -> CategoryResultNode:
         """Process a category node from criteria tree and create result node."""
-        return self.__process_holder(category)
+        return self.__process_holder(
+            category,
+            submission_files=submission_files,
+            sandbox=sandbox,
+            submission_language=submission_language,
+        )
 
     def __find_first_test(self, node: CategoryNode | SubjectNode) -> Optional[TestNode]:
         """Find the first test node in the tree."""

--- a/autograder/steps/grade_step.py
+++ b/autograder/steps/grade_step.py
@@ -45,20 +45,15 @@ class GradeStep(Step):
             if pipeline_exec.has_step_result(StepName.PRE_FLIGHT):
                 sandbox = pipeline_exec.get_step_result(StepName.PRE_FLIGHT).data
 
-            if sandbox:
-                self._grader_service.set_sandbox(sandbox)
-
             if not sandbox and template.requires_sandbox:
                 raise RuntimeError("Grading template requires a sandbox environment, but no sandbox was created")
-
-            # Set submission language for command resolution
-            if pipeline_exec.submission.language:
-                self._grader_service.set_submission_language(pipeline_exec.submission.language)
 
             criteria_tree = pipeline_exec.get_step_result(StepName.BUILD_TREE).data
             result_tree = self._grader_service.grade_from_tree(
                 criteria_tree=criteria_tree,
-                submission_files=pipeline_exec.submission.submission_files
+                submission_files=pipeline_exec.submission.submission_files,
+                sandbox=sandbox,
+                submission_language=pipeline_exec.submission.language,
             )
 
             # Create grading result

--- a/tests/unit/test_command_resolution_at_build_time.py
+++ b/tests/unit/test_command_resolution_at_build_time.py
@@ -45,10 +45,7 @@ class RecordingTestFunction(TestFunction):
 
 
 def _make_grader(language=None) -> GraderService:
-    svc = GraderService()
-    if language:
-        svc.set_submission_language(language)
-    return svc
+    return GraderService(), language
 
 
 def _make_test_node(params: dict, fn: TestFunction = None) -> TestNode:
@@ -66,7 +63,7 @@ class TestDictCommandResolutionInProcessTest:
 
     def test_dict_command_resolved_for_python(self):
         """Test proper dict resolution for Python language."""
-        svc = _make_grader(Language.PYTHON)
+        svc, language = _make_grader(Language.PYTHON)
         fn = RecordingTestFunction()
         node = _make_test_node({
             "program_command": {
@@ -75,13 +72,13 @@ class TestDictCommandResolutionInProcessTest:
             }
         }, fn)
 
-        svc.process_test(node)
+        svc.process_test(node, submission_language=language)
 
         assert fn.recorded_kwargs["program_command"] == "python3 calc.py"
 
     def test_dict_command_resolved_for_java(self):
         """Test proper dict resolution for Java language."""
-        svc = _make_grader(Language.JAVA)
+        svc, language = _make_grader(Language.JAVA)
         fn = RecordingTestFunction()
         node = _make_test_node({
             "program_command": {
@@ -90,13 +87,13 @@ class TestDictCommandResolutionInProcessTest:
             }
         }, fn)
 
-        svc.process_test(node)
+        svc.process_test(node, submission_language=language)
 
         assert fn.recorded_kwargs["program_command"] == "java Calc"
 
     def test_dict_command_missing_language_gives_none(self):
         """When language is not in the dict, resolved value is None."""
-        svc = _make_grader(Language.NODE)
+        svc, language = _make_grader(Language.NODE)
         fn = RecordingTestFunction()
         node = _make_test_node({
             "program_command": {
@@ -105,7 +102,7 @@ class TestDictCommandResolutionInProcessTest:
             }
         }, fn)
 
-        svc.process_test(node)
+        svc.process_test(node, submission_language=language)
 
         assert fn.recorded_kwargs["program_command"] is None
 
@@ -119,31 +116,31 @@ class TestCmdPlaceholderResolution:
 
     def test_cmd_resolved_for_python(self):
         """Test CMD placeholder resolves appropriately for Python."""
-        svc = _make_grader(Language.PYTHON)
+        svc, language = _make_grader(Language.PYTHON)
         fn = RecordingTestFunction()
         node = _make_test_node({"program_command": "CMD"}, fn)
 
-        svc.process_test(node)
+        svc.process_test(node, submission_language=language)
 
         assert fn.recorded_kwargs["program_command"] == "python3 main.py"
 
     def test_cmd_resolved_for_java(self):
         """Test CMD placeholder resolves appropriately for Java."""
-        svc = _make_grader(Language.JAVA)
+        svc, language = _make_grader(Language.JAVA)
         fn = RecordingTestFunction()
         node = _make_test_node({"program_command": "CMD"}, fn)
 
-        svc.process_test(node)
+        svc.process_test(node, submission_language=language)
 
         assert fn.recorded_kwargs["program_command"] == "java Main"
 
     def test_cmd_resolved_for_node(self):
         """Test CMD placeholder resolves appropriately for Node.js."""
-        svc = _make_grader(Language.NODE)
+        svc, language = _make_grader(Language.NODE)
         fn = RecordingTestFunction()
         node = _make_test_node({"program_command": "CMD"}, fn)
 
-        svc.process_test(node)
+        svc.process_test(node, submission_language=language)
 
         assert fn.recorded_kwargs["program_command"] == "node index.js"
 
@@ -157,11 +154,11 @@ class TestInvalidFormatHandled:
 
     def test_invalid_string_command_is_none(self):
         """Test non-CMD single strings fall back to None directly."""
-        svc = _make_grader(Language.PYTHON)
+        svc, language = _make_grader(Language.PYTHON)
         fn = RecordingTestFunction()
         node = _make_test_node({"program_command": "python3 my_script.py"}, fn)
 
-        svc.process_test(node)
+        svc.process_test(node, submission_language=language)
 
         # Non-CMD strings are invalid without legacy fallback, returning None
         assert fn.recorded_kwargs["program_command"] is None
@@ -176,23 +173,23 @@ class TestNoLanguageNoResolution:
 
     def test_dict_unchanged_when_no_language(self):
         """Without language, dict program_command is left as-is (resolver not called)."""
-        svc = _make_grader()          # no language
+        svc, language = _make_grader()          # no language
         fn = RecordingTestFunction()
         cmd_dict = {"python": "python3 calc.py"}
         node = _make_test_node({"program_command": cmd_dict}, fn)
 
-        svc.process_test(node)
+        svc.process_test(node, submission_language=language)
 
         # Dict should reach execute() untouched — resolution was skipped
         assert fn.recorded_kwargs["program_command"] == cmd_dict
 
     def test_cmd_unchanged_when_no_language(self):
         """Without language, CMD placeholder is unchanged (resolver not called)."""
-        svc = _make_grader()
+        svc, language = _make_grader()
         fn = RecordingTestFunction()
         node = _make_test_node({"program_command": "CMD"}, fn)
 
-        svc.process_test(node)
+        svc.process_test(node, submission_language=language)
 
         assert fn.recorded_kwargs["program_command"] == "CMD"
 
@@ -206,33 +203,33 @@ class TestNoHiddenKwarg:
 
     def test_no_hidden_kwarg_with_language_set(self):
         """Even when language is set, __submission_language__ must not appear in execute()."""
-        svc = _make_grader(Language.PYTHON)
+        svc, language = _make_grader(Language.PYTHON)
         fn = RecordingTestFunction()
         node = _make_test_node({"program_command": "CMD"}, fn)
 
-        svc.process_test(node)
+        svc.process_test(node, submission_language=language)
 
         assert "__submission_language__" not in fn.recorded_kwargs
 
     def test_no_hidden_kwarg_without_language(self):
         """Hidden kwarg shouldn't appear even if there is no language to configure."""
-        svc = _make_grader()
+        svc, language = _make_grader()
         fn = RecordingTestFunction()
         node = _make_test_node({}, fn)
 
-        svc.process_test(node)
+        svc.process_test(node, submission_language=language)
 
         assert "__submission_language__" not in fn.recorded_kwargs
 
     def test_no_hidden_kwarg_with_dict_command(self):
         """Hidden kwarg shouldn't appear even if there is a dict correctly configured."""
-        svc = _make_grader(Language.JAVA)
+        svc, language = _make_grader(Language.JAVA)
         fn = RecordingTestFunction()
         node = _make_test_node({
             "program_command": {"python": "python3 a.py", "java": "java A"}
         }, fn)
 
-        svc.process_test(node)
+        svc.process_test(node, submission_language=language)
 
         assert "__submission_language__" not in fn.recorded_kwargs
 


### PR DESCRIPTION
## Summary
- refactored `GraderService` to remove mutable setter-based state (`set_sandbox`, `set_submission_language`, hidden internal submission state)
- updated `grade_from_tree` and tree traversal helpers to receive `sandbox`, `submission_language`, and `submission_files` explicitly
- updated `GradeStep` to pass required grading context directly
- updated command-resolution unit tests to exercise explicit parameter flow

## Why
Issue #221 requires stateless grading APIs to avoid hidden mutable state and make service reuse safe across submissions.

## Validation
- `pytest -q tests/unit/test_command_resolution_at_build_time.py tests/unit/pipeline/test_pipeline_steps.py tests/unit/pipeline/test_multi_language_pipeline.py` ✅
- Full `pytest` baseline currently fails in clean main due missing local dependency `asyncpg` during collection (pre-existing environment limitation).

Closes #221
