### PR TITLE
[TD][Templates] Unify template registration in service layer (#223)

### DIFF
--- a/autograder/services/template_library_service.py
+++ b/autograder/services/template_library_service.py
@@ -8,9 +8,11 @@ This is a singleton service that should be instantiated once at application star
 """
 
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Type
 from autograder.models.abstract.template import Template
-from autograder.template_library import TEMPLATE_REGISTRY, get_template_instance
+from autograder.template_library.web_dev import WebDevTemplate
+from autograder.template_library.api_testing import ApiTestingTemplate
+from autograder.template_library.input_output import InputOutputTemplate
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +31,11 @@ class TemplateLibraryService:
 
     _instance: Optional['TemplateLibraryService'] = None
     _initialized: bool = False
+    _TEMPLATE_REGISTRY: Dict[str, Type[Template]] = {
+        "webdev": WebDevTemplate,
+        "api": ApiTestingTemplate,
+        "input_output": InputOutputTemplate,
+    }
 
     def __new__(cls):
         """Ensure only one instance of the service exists."""
@@ -48,9 +55,10 @@ class TemplateLibraryService:
 
     def _load_all_templates(self):
         """Load and cache all template instances at startup."""
-        for template_name in TEMPLATE_REGISTRY:
+        for template_name in self._TEMPLATE_REGISTRY:
             try:
-                self._templates[template_name] = get_template_instance(template_name)
+                template_class = self._TEMPLATE_REGISTRY[template_name]
+                self._templates[template_name] = template_class()
             except Exception as e:
                 # Log the error but continue loading other templates
                 logger.warning("Failed to load template '%s': %s", template_name, e)
@@ -137,7 +145,7 @@ class TemplateLibraryService:
         Returns:
             A list of template identifier strings
         """
-        return list(TEMPLATE_REGISTRY.keys())
+        return list(self._TEMPLATE_REGISTRY.keys())
 
     def get_all_templates_info(self) -> List[dict]:
         """
@@ -199,4 +207,3 @@ class TemplateLibraryService:
             NotImplementedError: This feature is not yet implemented
         """
         raise NotImplementedError("Custom template loading is not yet implemented. This feature requires sandboxed environment support.")
-

--- a/autograder/template_library/__init__.py
+++ b/autograder/template_library/__init__.py
@@ -1,65 +1,11 @@
-"""
-Template Library Module
-
-This module provides a registry for all available templates in the autograder system.
-Templates can be accessed by their string identifiers through the TEMPLATE_REGISTRY.
-"""
+"""Template library package exports."""
 
 from autograder.template_library.web_dev import WebDevTemplate
 from autograder.template_library.api_testing import ApiTestingTemplate
 from autograder.template_library.input_output import InputOutputTemplate
 
-# Template Registry: Maps template identifiers to their template classes
-TEMPLATE_REGISTRY = {
-    "webdev": WebDevTemplate,
-    "api": ApiTestingTemplate,
-    "input_output": InputOutputTemplate,
-}
-
-
-def get_template(template_name: str):
-    """
-    Retrieve a template class by its string identifier.
-
-    Args:
-        template_name: The string identifier for the template (e.g., "webdev", "api", "essay", "IO")
-
-    Returns:
-        The template class corresponding to the given identifier
-
-    Raises:
-        KeyError: If the template name is not found in the registry
-    """
-    if template_name not in TEMPLATE_REGISTRY:
-        available = ", ".join(TEMPLATE_REGISTRY.keys())
-        raise KeyError(f"Template '{template_name}' not found. Available templates: {available}")
-
-    return TEMPLATE_REGISTRY[template_name]
-
-
-def get_template_instance(template_name: str):
-    """
-    Retrieve an instantiated template by its string identifier.
-
-    Args:
-        template_name: The string identifier for the template (e.g., "webdev", "api", "essay", "IO")
-
-    Returns:
-        An instance of the template class corresponding to the given identifier
-
-    Raises:
-        KeyError: If the template name is not found in the registry
-    """
-    template_class = get_template(template_name)
-    return template_class()
-
-
 __all__ = [
-    "TEMPLATE_REGISTRY",
-    "get_template",
-    "get_template_instance",
     "WebDevTemplate",
     "ApiTestingTemplate",
     "InputOutputTemplate",
 ]
-


### PR DESCRIPTION
## Summary
- moved built-in template registry ownership into `TemplateLibraryService`
- switched service startup instantiation to use the service-owned registry directly
- removed module-level template registry helpers from `autograder.template_library.__init__`
- kept runtime consumers on `TemplateLibraryService` API, preserving call-site behavior

## Why
Issue #223 requests a single authoritative template registration path to remove the current dual system and reduce registry drift risk.

## Validation
- `pytest -q tests/unit/pipeline/test_pipeline_steps.py tests/unit/pipeline/test_multi_language_pipeline.py tests/unit/test_command_resolution_at_build_time.py` ✅

Closes #223
