### PR TITLE
[TD][PipelineExecution] Add typed accessors and step adoption (#224)

### DIFF
--- a/autograder/autograder.py
+++ b/autograder/autograder.py
@@ -105,8 +105,7 @@ class AutograderPipeline:
             if pipeline_execution.has_step_result(StepName.PRE_FLIGHT):
                 from sandbox_manager.manager import get_sandbox_manager
 
-                preflight_result = pipeline_execution.get_step_result(StepName.PRE_FLIGHT)
-                sandbox = preflight_result.data
+                sandbox = pipeline_execution.get_sandbox()
 
                 if sandbox:  # Only if a sandbox was created
                     manager = get_sandbox_manager()

--- a/autograder/models/pipeline_execution.py
+++ b/autograder/models/pipeline_execution.py
@@ -1,11 +1,19 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, TYPE_CHECKING, cast
 import time
 
 from autograder.models.dataclass.grading_result import GradingResult
 from autograder.models.dataclass.step_result import StepResult, StepName, StepStatus
 from autograder.models.dataclass.submission import Submission
+
+if TYPE_CHECKING:
+    from autograder.models.abstract.template import Template
+    from autograder.models.criteria_tree import CriteriaTree
+    from autograder.models.dataclass.focus import Focus
+    from autograder.models.dataclass.grade_step_result import GradeStepResult
+    from autograder.models.result_tree import ResultTree
+    from sandbox_manager.sandbox_container import SandboxContainer
 
 
 class PipelineStatus(Enum):
@@ -191,6 +199,59 @@ class PipelineExecution:
     def has_step_result(self, step_name: StepName) -> bool:
         return any(step_result.step == step_name for step_result in self.step_results)
 
+    def _require_step_data(self, step_name: StepName, artifact_name: str) -> Any:
+        step_result = self.get_step_result(step_name)
+        if step_result.data is None:
+            raise ValueError(
+                f"Step {step_name.value} did not produce required {artifact_name} data."
+            )
+        return step_result.data
+
+    def get_loaded_template(self) -> "Template":
+        return cast(
+            "Template",
+            self._require_step_data(StepName.LOAD_TEMPLATE, "template"),
+        )
+
+    def get_built_criteria_tree(self) -> "CriteriaTree":
+        return cast(
+            "CriteriaTree",
+            self._require_step_data(StepName.BUILD_TREE, "criteria tree"),
+        )
+
+    def get_sandbox(self) -> Optional["SandboxContainer"]:
+        if not self.has_step_result(StepName.PRE_FLIGHT):
+            return None
+        return cast(
+            Optional["SandboxContainer"],
+            self.get_step_result(StepName.PRE_FLIGHT).data,
+        )
+
+    def get_grade_step_result(self) -> "GradeStepResult":
+        return cast(
+            "GradeStepResult",
+            self._require_step_data(StepName.GRADE, "grade result"),
+        )
+
+    def get_result_tree(self) -> "ResultTree":
+        return cast("ResultTree", self.get_grade_step_result().result_tree)
+
+    def require_focus(self) -> "Focus":
+        return cast(
+            "Focus",
+            self._require_step_data(StepName.FOCUS, "focus"),
+        )
+
+    def get_focus(self) -> Optional["Focus"]:
+        if not self.has_step_result(StepName.FOCUS):
+            return None
+        return cast(Optional["Focus"], self.get_step_result(StepName.FOCUS).data)
+
+    def get_feedback(self) -> Optional[str]:
+        if not self.has_step_result(StepName.FEEDBACK):
+            return None
+        return cast(Optional[str], self.get_step_result(StepName.FEEDBACK).data)
+
     def get_previous_step(self) -> Optional[StepResult]:
         return self.step_results[-1] if self.step_results else None
 
@@ -206,11 +267,15 @@ class PipelineExecution:
         grading_result = None
         if self.status != PipelineStatus.FAILED:
             self.status = PipelineStatus.SUCCESS
+            grade_result = self.get_grade_step_result()
+            feedback = self.get_feedback()
+            if self.has_step_result(StepName.FEEDBACK) and feedback is None:
+                raise ValueError("Feedback step exists but produced no feedback content.")
             grading_result = GradingResult(
-                final_score=self.get_step_result(StepName.GRADE).data.final_score,
-                feedback=self.get_step_result(StepName.FEEDBACK).data if self.has_step_result(StepName.FEEDBACK) else None,
-                result_tree=self.get_step_result(StepName.GRADE).data.result_tree,
-                focus=self.get_step_result(StepName.FOCUS).data if self.has_step_result(StepName.FOCUS) else None
+                final_score=grade_result.final_score,
+                feedback=feedback,
+                result_tree=grade_result.result_tree,
+                focus=self.get_focus(),
             )
         self.result = grading_result
 
@@ -230,4 +295,3 @@ class PipelineExecution:
 
         pipeline_execution.add_step_result(bootstrap)
         return pipeline_execution
-

--- a/autograder/steps/build_tree_step.py
+++ b/autograder/steps/build_tree_step.py
@@ -40,7 +40,7 @@ class BuildTreeStep(Step):
             logger.info("Building criteria tree (external_user_id=%s)", pipeline_exec.submission.user_id)
             # Validate criteria configuration
             criteria_config = CriteriaConfig.from_dict(self._criteria_json)
-            template = pipeline_exec.get_step_result(StepName.LOAD_TEMPLATE).data
+            template = pipeline_exec.get_loaded_template()
             # Build the criteria tree with embedded test functions
             criteria_tree = self._criteria_tree_service.build_tree(
                 criteria_config,

--- a/autograder/steps/export_step.py
+++ b/autograder/steps/export_step.py
@@ -26,7 +26,7 @@ class ExporterStep(Step):
         try:
             # Extract external_user_id and score from input
             external_user_id = pipeline_exec.submission.user_id
-            score = pipeline_exec.get_step_result(StepName.GRADE).data.final_score
+            score = pipeline_exec.get_grade_step_result().final_score
 
             logger.info("Exporting result: external_user_id=%s, score=%.2f", external_user_id, score)
             self._exporter_service.set_score(external_user_id, score)

--- a/autograder/steps/feedback_step.py
+++ b/autograder/steps/feedback_step.py
@@ -2,8 +2,8 @@ import logging
 
 from autograder.models.abstract.step import Step
 from autograder.models.dataclass.focus import Focus 
+from autograder.models.dataclass.step_result import StepName, StepResult, StepStatus
 from autograder.models.pipeline_execution import PipelineExecution
-from autograder.models.dataclass.step_result import StepName, StepResult
 from autograder.services.report.reporter_service import ReporterService
 
 logger = logging.getLogger(__name__)
@@ -25,20 +25,22 @@ class FeedbackStep(Step):
         """Adds feedback to the grading result using the reporter service."""
         try:
             logger.info("Generating feedback (external_user_id=%s)", pipeline_exec.submission.user_id)
-            focused_tests: Focus = pipeline_exec.get_step_result(StepName.FOCUS).data
-            grade_result = pipeline_exec.get_step_result(StepName.GRADE).data
+            focused_tests: Focus = pipeline_exec.require_focus()
+            result_tree = pipeline_exec.get_result_tree()
             
             feedback_content = self._reporter_service.generate_feedback(
                 grading_result=focused_tests,
-                result_tree=grade_result.result_tree,
+                result_tree=result_tree,
                 feedback_config=self._feedback_config
             )
-            feedback = StepResult.success(
-                step=StepName.FEEDBACK,
-                data=feedback_content
-            )
             logger.info("Feedback generated (external_user_id=%s)", pipeline_exec.submission.user_id)
-            return pipeline_exec.add_step_result(feedback)
+            return pipeline_exec.add_step_result(
+                StepResult(
+                    step=StepName.FEEDBACK,
+                    data=feedback_content,
+                    status=StepStatus.SUCCESS,
+                )
+            )
         except (ValueError, KeyError, AttributeError, TypeError, RuntimeError) as e:
             logger.error(
                 "Feedback generation failed: external_user_id=%s, error=%s",
@@ -46,8 +48,10 @@ class FeedbackStep(Step):
                 str(e),
             )
             return pipeline_exec.add_step_result(
-                StepResult.fail(
+                StepResult(
                     step=StepName.FEEDBACK,
-                    error=f"Failed to generate feedback: {str(e)}"
+                    data=None,
+                    status=StepStatus.FAIL,
+                    error=f"Failed to generate feedback: {str(e)}",
                 )
             )

--- a/autograder/steps/focus_step.py
+++ b/autograder/steps/focus_step.py
@@ -1,7 +1,7 @@
 import logging
 
 from autograder.models.abstract.step import Step
-from autograder.models.dataclass.step_result import StepName, StepResult, StepStatus
+from autograder.models.dataclass.step_result import StepResult, StepStatus
 from autograder.models.pipeline_execution import PipelineExecution
 from autograder.services.focus_service import FocusService
 
@@ -27,7 +27,7 @@ class FocusStep(Step):
 
         try:
             logger.info("Identifying focus areas (external_user_id=%s)", pipeline_exec.submission.user_id)
-            result_tree = pipeline_exec.get_step_result(StepName.GRADE).data.result_tree
+            result_tree = pipeline_exec.get_result_tree()
             main_subjects = self.__focus_service.find(result_tree)
             logger.info(
                 "Focus areas identified (external_user_id=%s)",

--- a/autograder/steps/grade_step.py
+++ b/autograder/steps/grade_step.py
@@ -38,12 +38,10 @@ class GradeStep(Step):
             logger.info("Grading submission (external_user_id=%s)", pipeline_exec.submission.user_id)
 
             # If submission is sandboxed, feed grading template with container ref
-            template = pipeline_exec.get_step_result(StepName.LOAD_TEMPLATE).data
+            template = pipeline_exec.get_loaded_template()
 
             # Check if PRE_FLIGHT step was executed (only if setup_config was provided)
-            sandbox = None
-            if pipeline_exec.has_step_result(StepName.PRE_FLIGHT):
-                sandbox = pipeline_exec.get_step_result(StepName.PRE_FLIGHT).data
+            sandbox = pipeline_exec.get_sandbox()
 
             if sandbox:
                 self._grader_service.set_sandbox(sandbox)
@@ -55,7 +53,7 @@ class GradeStep(Step):
             if pipeline_exec.submission.language:
                 self._grader_service.set_submission_language(pipeline_exec.submission.language)
 
-            criteria_tree = pipeline_exec.get_step_result(StepName.BUILD_TREE).data
+            criteria_tree = pipeline_exec.get_built_criteria_tree()
             result_tree = self._grader_service.grade_from_tree(
                 criteria_tree=criteria_tree,
                 submission_files=pipeline_exec.submission.submission_files

--- a/autograder/steps/pre_flight_step.py
+++ b/autograder/steps/pre_flight_step.py
@@ -73,7 +73,7 @@ class PreFlightStep(Step):
                         original_input=pipeline_exec
                         ))
 
-        grading_template = pipeline_exec.get_step_result(StepName.LOAD_TEMPLATE).data
+        grading_template = pipeline_exec.get_loaded_template()
         if grading_template.requires_sandbox:
             logger.info("Creating sandbox for submission (external_user_id=%s)", pipeline_exec.submission.user_id)
             sandbox = self._pre_flight_service.create_sandbox(pipeline_exec.submission) # Needs error handling?
@@ -118,4 +118,3 @@ class PreFlightStep(Step):
             return "Unknown preflight error"
         error_messages = self._pre_flight_service.get_error_messages()
         return "\n".join(error_messages)
-

--- a/tests/unit/pipeline/test_pipeline_execution_accessors.py
+++ b/tests/unit/pipeline/test_pipeline_execution_accessors.py
@@ -1,0 +1,64 @@
+from autograder.models.criteria_tree import CategoryNode, CriteriaTree
+from autograder.models.dataclass.focus import Focus
+from autograder.models.dataclass.grade_step_result import GradeStepResult
+from autograder.models.dataclass.step_result import StepName, StepResult, StepStatus
+from autograder.models.dataclass.submission import Submission, SubmissionFile
+from autograder.models.pipeline_execution import PipelineExecution
+from autograder.models.result_tree import CategoryResultNode, ResultTree, RootResultNode
+from autograder.template_library.input_output import InputOutputTemplate
+
+
+def _build_pipeline_execution() -> PipelineExecution:
+    submission = Submission(
+        username="student",
+        user_id=1,
+        assignment_id=7,
+        submission_files={"main.py": SubmissionFile(filename="main.py", content="print('ok')")},
+    )
+    return PipelineExecution.start_execution(submission)
+
+
+def test_typed_accessors_return_expected_artifacts():
+    pipeline_exec = _build_pipeline_execution()
+
+    template = InputOutputTemplate()
+    tree = CriteriaTree(base=CategoryNode(name="base", weight=100))
+    result_tree = ResultTree(root=RootResultNode(base=CategoryResultNode(name="base", weight=100)))
+    result_tree.root.base.score = 100.0
+    result_tree.root.score = 100.0
+    grade = GradeStepResult(final_score=100.0, result_tree=result_tree)
+    focus = Focus(base=[], penalty=[], bonus=[])
+
+    pipeline_exec.add_step_result(StepResult(step=StepName.LOAD_TEMPLATE, data=template, status=StepStatus.SUCCESS))
+    pipeline_exec.add_step_result(StepResult(step=StepName.BUILD_TREE, data=tree, status=StepStatus.SUCCESS))
+    pipeline_exec.add_step_result(StepResult(step=StepName.GRADE, data=grade, status=StepStatus.SUCCESS))
+    pipeline_exec.add_step_result(StepResult(step=StepName.FOCUS, data=focus, status=StepStatus.SUCCESS))
+    pipeline_exec.add_step_result(StepResult(step=StepName.FEEDBACK, data="ok", status=StepStatus.SUCCESS))
+
+    assert pipeline_exec.get_loaded_template() is template
+    assert pipeline_exec.get_built_criteria_tree() is tree
+    assert pipeline_exec.get_grade_step_result() is grade
+    assert pipeline_exec.get_result_tree() is result_tree
+    assert pipeline_exec.require_focus() is focus
+    assert pipeline_exec.get_focus() is focus
+    assert pipeline_exec.get_feedback() == "ok"
+    assert pipeline_exec.get_sandbox() is None
+
+
+def test_typed_accessors_raise_on_missing_required_artifacts():
+    pipeline_exec = _build_pipeline_execution()
+
+    try:
+        pipeline_exec.get_loaded_template()
+        assert False, "Expected ValueError for missing template step"
+    except ValueError as exc:
+        assert "template" in str(exc).lower()
+
+    pipeline_exec.add_step_result(
+        StepResult(step=StepName.LOAD_TEMPLATE, data=None, status=StepStatus.FAIL, error="boom")
+    )
+    try:
+        pipeline_exec.get_loaded_template()
+        assert False, "Expected ValueError for missing template data"
+    except ValueError as exc:
+        assert "required" in str(exc).lower()


### PR DESCRIPTION
## Summary
- added typed `PipelineExecution` accessors for common artifacts: loaded template, built criteria tree, sandbox, grade result, result tree, focus, and feedback
- added guard helpers for required step data with explicit errors when data is missing
- refactored pipeline steps (`BuildTree`, `PreFlight`, `Grade`, `Focus`, `Feedback`, `Exporter`) and pipeline sandbox cleanup to use typed accessors instead of raw `get_step_result(...).data`
- added dedicated accessor tests for success paths and missing-data errors

## Why
Issue #224 asks for typed pipeline data access to reduce brittle implicit casts and improve maintainability/readability across steps.

## Validation
- `pytest -q tests/unit/pipeline/test_pipeline_execution_accessors.py tests/unit/pipeline/test_pipeline_steps.py tests/unit/pipeline/test_feedback_step_integration.py tests/unit/pipeline/test_multi_language_pipeline.py` ✅

Closes #224
