### PR TITLE
fix: Penalty logic

### DIFF
--- a/autograder/models/result_tree.py
+++ b/autograder/models/result_tree.py
@@ -266,8 +266,8 @@ class RootResultNode:
         penalty_points = 0.0
         if self.penalty:
             penalty_score = self.penalty.calculate_score()
-            # Penalty subtracts: (penalty_score / 100) * penalty_weight
-            penalty_points = (penalty_score / 100.0) * self.penalty.weight
+            # Penalty subtracts: ((100 - penalty_score) / 100) * penalty_weight
+            penalty_points = ((100.0 - penalty_score) / 100.0) * self.penalty.weight
 
         # Final score = base + bonus - penalty (capped at 0-100)
         self.score = max(0.0, min(100.0, base_score + bonus_points - penalty_points))

--- a/autograder/services/focus_service.py
+++ b/autograder/services/focus_service.py
@@ -69,12 +69,13 @@ class FocusService:
 
         # Initial Multiplier for a Category Root is 1.0 (100%)
         # Logic follows the same split as Subject if subjects_weight exists
-        subj_mult = 1.0
-        test_mult = 1.0
+        initial_mult = category.weight / 100.0
+        subj_mult = initial_mult
+        test_mult = initial_mult
 
         if category.subjects_weight is not None:
-            subj_mult = category.subjects_weight / 100
-            test_mult = (100 - category.subjects_weight) / 100
+            subj_mult *= category.subjects_weight / 100.0
+            test_mult *= (100.0 - category.subjects_weight) / 100.0
 
         for subject in category.subjects:
             child_weight_factor = subject.weight / 100

--- a/autograder/steps/focus_step.py
+++ b/autograder/steps/focus_step.py
@@ -1,7 +1,7 @@
 import logging
 
 from autograder.models.abstract.step import Step
-from autograder.models.dataclass.step_result import StepResult, StepStatus
+from autograder.models.dataclass.step_result import StepName, StepResult, StepStatus
 from autograder.models.pipeline_execution import PipelineExecution
 from autograder.services.focus_service import FocusService
 


### PR DESCRIPTION
Fixed a critical logic error in how penalty points were calculated and applied to the final grade. The previous implementation incorrectly subtracted points even when penalty-marked tests passed, or used an inverted logic that led to inconsistent grading.

Technical Changes
`autograder/models/result_tree.py`
Modified `RootResultNode.calculate_score()` to correctly handle the PENALTY category.

Old Logic: The calculation was not properly reflecting the "deduction" nature of the penalty, often leading to inconsistent final scores when penalty tests were present.

New Logic: The impact of penalties is now calculated as the inverse of the penalty group's score.

A penalty score of 100% (no violations) results in 0 deduction points.
A penalty score of 0% (full violation) results in the full penalty weight being subtracted from the final grade.
Formula implemented: penalty_points = ((100.0 - penalty_score) / 100.0) * self.penalty.weight


**Fixed**:  NameError in FocusStep caused by a missing import, which was previously interrupting the pipeline. Also corrected the test impact logic in FocusService to properly account for category weights (bonus/penalty).