### PR TITLE
233 td formalize exporter plugin interface

### DIFF
--- a/autograder/autograder.py
+++ b/autograder/autograder.py
@@ -129,6 +129,7 @@ def build_pipeline(
     custom_template=None,
     feedback_mode=None,
     export_results=False,
+    exporter=None,
     locale="en",
 ) -> AutograderPipeline:
     """
@@ -156,6 +157,7 @@ def build_pipeline(
         "custom_template": custom_template,
         "feedback_mode": feedback_mode,
         "export_results": export_results,
+        "exporter": exporter,
         "locale": locale,
     }
     registry = StepRegistry(config)

--- a/autograder/models/abstract/exporter.py
+++ b/autograder/models/abstract/exporter.py
@@ -1,0 +1,26 @@
+"""Abstract interface for grade exporters."""
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+
+class Exporter(ABC):
+    """
+    Abstract base class for grade exporters.
+
+    Any system that receives grading results (Upstash Redis, GitHub Classroom, etc.)
+    must implement this interface to be usable with the pipeline's ExporterStep.
+    """
+
+    @abstractmethod
+    def export(self, user_id: str, score: float, feedback: Optional[str] = None) -> None:
+        """
+        Export a grading result to an external system.
+
+        Args:
+            user_id: External identifier for the student.
+            score: Final numeric score (0-100).
+            feedback: Optional feedback text. Exporters may ignore this
+                      if they only handle scores.
+        """
+        pass

--- a/autograder/services/upstash_driver.py
+++ b/autograder/services/upstash_driver.py
@@ -1,13 +1,16 @@
 import json
 import logging
 import os
+from typing import Optional
 from dotenv import load_dotenv
 from upstash_redis import Redis
+
+from autograder.models.abstract.exporter import Exporter
 
 logger = logging.getLogger(__name__)
 
 load_dotenv() #TODO: place this in application startup
-class UpstashDriver:
+class UpstashDriver(Exporter):
     def __init__(self):
         self.redis = Redis(
             os.getenv("UPSTASH_REDIS_URL"),
@@ -59,4 +62,8 @@ class UpstashDriver:
         key = f"user:{username}"
         self.redis.hset(key, "score", score)
         logger.info("Score '%s' set for user '%s'.", score, username)
+
+    def export(self, user_id: str, score: float, feedback: Optional[str] = None) -> None:
+        """Export score to Upstash Redis. Feedback is not stored."""
+        self.set_score(user_id, score)
 

--- a/autograder/steps/export_step.py
+++ b/autograder/steps/export_step.py
@@ -1,5 +1,7 @@
 import logging
+from typing import Optional
 
+from autograder.models.abstract.exporter import Exporter
 from autograder.models.abstract.step import Step
 from autograder.models.pipeline_execution import PipelineExecution
 from autograder.models.dataclass.step_result import StepResult, StepStatus, StepName
@@ -9,10 +11,11 @@ logger = logging.getLogger(__name__)
 
 class ExporterStep(Step):
     """
-    Step that exports the final grading result to an external system (e.g., Upstash).
+    Step that exports the final grading result to an external system
+    via a pluggable Exporter implementation.
     """
 
-    def __init__(self, exporter_service):
+    def __init__(self, exporter_service: Exporter):
         self._exporter_service = exporter_service
 
     @property
@@ -27,12 +30,13 @@ class ExporterStep(Step):
         Returns:
             PipelineExecution with an added StepResult indicating success or failure of the export operation
         """
-        # Extract external_user_id and score from input
+        # Extract external_user_id, score and optional feedback
         external_user_id = pipeline_exec.submission.user_id
         score = pipeline_exec.get_grade_step_result().final_score
+        feedback: Optional[str] = pipeline_exec.get_feedback()
 
         logger.info("Exporting result: external_user_id=%s, score=%.2f", external_user_id, score)
-        self._exporter_service.set_score(external_user_id, score)
+        self._exporter_service.export(external_user_id, score, feedback)
         logger.info("Result exported successfully: external_user_id=%s", external_user_id)
 
         # Return success result
@@ -41,3 +45,4 @@ class ExporterStep(Step):
             data=None,
             status=StepStatus.SUCCESS
         ))
+

--- a/autograder/steps/step_registry.py
+++ b/autograder/steps/step_registry.py
@@ -74,7 +74,8 @@ class StepRegistry:
 
     def _build_exporter(self) -> Optional[Step]:
         if self.config.get("export_results"):
-            return ExporterStep(UpstashDriver)
+            exporter = self.config.get("exporter") or UpstashDriver()
+            return ExporterStep(exporter)
         return None
 
     def build_step(self, step_name: StepName) -> Optional[Step]:

--- a/docs/roadmaps/TECHNICAL_DEBT_ROADMAP.md
+++ b/docs/roadmaps/TECHNICAL_DEBT_ROADMAP.md
@@ -294,7 +294,7 @@ These items prepare the codebase for future growth by establishing patterns and 
 | 15 | Decouple UpstashDriver env loading | 🟢 P3 | ⬜ To Do |
 | 16 | Standardize Template ABC | 🟢 P3 | ⬜ To Do |
 | 17 | Step registry pattern | 🔵 P4 | ✅ Done |
-| 18 | Formalize exporter plugin | 🔵 P4 | ⬜ To Do |
+| 18 | Formalize exporter plugin | 🔵 P4 | ✅ Done |
 | 19 | Separate summary from model | 🔵 P4 | ✅ Done |
 | 20 | Consistent error handling | 🔵 P4 | ⬜ To Do |
 | 21 | Decouple AiExecutor batch | 🔵 P4 | ⬜ To Do |

--- a/github_action/github_action_service.py
+++ b/github_action/github_action_service.py
@@ -3,6 +3,7 @@ import os
 
 from autograder.autograder import build_pipeline, AutograderPipeline
 from autograder.models.dataclass.submission import Submission
+from github_action.github_classroom_exporter import GithubClassroomExporter
 from github import Github
 from github.GithubException import UnknownObjectException
 from github.Repository import Repository
@@ -212,6 +213,8 @@ class GithubActionService:
         submission_path = os.path.join(base_path, "submission")
         configuration_path = os.path.join(submission_path, ".github", "autograder")
 
+        exporter = GithubClassroomExporter(self)
+
         return build_pipeline(
             template_name=template_preset,
             grading_criteria=self.__read_path(configuration_path, "criteria.json", False),
@@ -219,6 +222,8 @@ class GithubActionService:
             setup_config=self.__read_path(configuration_path, "setup.json"),
             include_feedback=include_feedback,
             feedback_mode=feedback_mode,
+            export_results=True,
+            exporter=exporter,
         )
 
     def __read_path(self, configuration_path: str, file_name: str, optional=True):

--- a/github_action/github_classroom_exporter.py
+++ b/github_action/github_classroom_exporter.py
@@ -1,0 +1,42 @@
+"""GitHub Classroom exporter that wraps the existing GithubActionService export logic."""
+
+import logging
+from typing import Optional, TYPE_CHECKING
+
+from autograder.models.abstract.exporter import Exporter
+
+if TYPE_CHECKING:
+    from github_action.github_action_service import GithubActionService
+
+logger = logging.getLogger(__name__)
+
+
+class GithubClassroomExporter(Exporter):
+    """
+    Exporter implementation for GitHub Classroom.
+
+    Wraps the existing GithubActionService.export_results() method,
+    which notifies GitHub Classroom of the score and optionally commits
+    feedback to the repository.
+    """
+
+    def __init__(self, github_action_service: "GithubActionService"):
+        self._service = github_action_service
+
+    def export(self, user_id: str, score: float, feedback: Optional[str] = None) -> None:
+        """
+        Export grading result to GitHub Classroom.
+
+        Args:
+            user_id: The student's identifier (not used directly — GitHub Classroom
+                     identifies the student by the repository/workflow context).
+            score: Final numeric score (0-100).
+            feedback: Optional feedback text to commit as relatorio.md.
+        """
+        include_feedback = feedback is not None
+        logger.info(
+            "Exporting to GitHub Classroom: score=%.2f, include_feedback=%s",
+            score,
+            include_feedback,
+        )
+        self._service.export_results(score, include_feedback, feedback)

--- a/github_action/main.py
+++ b/github_action/main.py
@@ -72,11 +72,8 @@ async def main():
 
         service = GithubActionService(args.github_token, args.app_token)
         pipeline = __build_pipeline(args, include_feedback, service)
-        grading_result = __retrieve_grading_score(args, service, pipeline)
+        __retrieve_grading_score(args, service, pipeline)
 
-        service.export_results(
-            grading_result.final_score, include_feedback, grading_result.feedback
-        )
         success_execution = True
     except ValueError as e:
         logger.error("Invalid value provided: %s", e)

--- a/tests/unit/github_action/test_github_action_service.py
+++ b/tests/unit/github_action/test_github_action_service.py
@@ -440,8 +440,12 @@ class TestAutograderPipeline:
             "os.path.exists", side_effect=fake_exists
         ), patch("builtins.open", side_effect=fake_open_read), patch(
             "github_action.github_action_service.build_pipeline"
-        ) as mock_build:
+        ) as mock_build, patch(
+            "github_action.github_action_service.GithubClassroomExporter"
+        ) as mock_exporter_cls:
             mock_build.return_value = MagicMock()
+            mock_exporter = MagicMock()
+            mock_exporter_cls.return_value = mock_exporter
             service.autograder_pipeline("python", True, "default")
 
         mock_build.assert_called_once_with(
@@ -451,6 +455,8 @@ class TestAutograderPipeline:
             setup_config=setup,
             include_feedback=True,
             feedback_mode="default",
+            export_results=True,
+            exporter=mock_exporter,
         )
 
     def test_raises_file_not_found_when_criteria_missing(self):

--- a/tests/unit/github_action/test_main.py
+++ b/tests/unit/github_action/test_main.py
@@ -78,12 +78,11 @@ class TestMain:
         mock_service_cls.assert_not_called()
 
     def test_successful_run_without_feedback(self):
-        """Asserts main() runs successfully and calls export_results with include_feedback=False when feedback is disabled."""
+        """Asserts main() runs successfully when feedback is disabled. Export happens inside the pipeline."""
         execution = _make_pipeline_execution(final_score=90.0, feedback="")
         mock_service = MagicMock()
         mock_service.autograder_pipeline.return_value = MagicMock()
         mock_service.run_autograder.return_value = execution
-        mock_service.export_results = MagicMock()
 
         with patch.object(sys, "argv", _make_argv(include_feedback="false")), patch(
             "github_action.main.GithubActionService", return_value=mock_service
@@ -91,30 +90,23 @@ class TestMain:
             run(main_module.main())
 
         mock_service.run_autograder.assert_called_once()
-        mock_service.export_results.assert_called_once_with(
-            90.0, False, execution.result.feedback
-        )
 
     def test_successful_run_with_feedback(self):
-        """Asserts main() runs successfully and calls export_results with include_feedback=True when feedback is enabled."""
+        """Asserts main() runs successfully when feedback is enabled. Export happens inside the pipeline."""
         execution = _make_pipeline_execution(final_score=75.0, feedback="Good work!")
         mock_service = MagicMock()
         mock_service.autograder_pipeline.return_value = MagicMock()
         mock_service.run_autograder.return_value = execution
-        mock_service.export_results = MagicMock()
 
         with patch.object(
             sys, "argv", _make_argv(include_feedback="true", openai_key=None)
         ), patch("github_action.main.GithubActionService", return_value=mock_service):
             run(main_module.main())
 
-        mock_service.export_results.assert_called_once_with(
-            75.0, True, execution.result.feedback
-        )
+        mock_service.run_autograder.assert_called_once()
 
     def test_raises_when_grading_result_is_none(self):
-        """main() raises SystemExit(1) when run_autograder returns None result;
-        verify run_autograder was reached and export_results was never called."""
+        """main() raises SystemExit(1) when run_autograder returns None result."""
         execution = MagicMock()
         execution.result = None
 
@@ -130,7 +122,6 @@ class TestMain:
 
         assert exc_info.value.code == 1
         mock_service.run_autograder.assert_called_once()
-        mock_service.export_results.assert_not_called()
 
     def test_sets_openai_api_key_env_when_provided(self):
         """Asserts OPENAI_API_KEY is set in the environment before autograder_pipeline is called when openai_key is provided."""
@@ -252,21 +243,22 @@ class TestHasFeedback:
         )
 
     def _invoke(self, value):
-        """Call __has_feedback through main() by inspecting its import branch."""
-        # The cleanest way: drive it through the include_feedback argv path
-        # and observe what export_results receives.
+        """Call __has_feedback through main() by inspecting the autograder_pipeline call."""
+        # Drive it through the include_feedback argv path
+        # and observe what autograder_pipeline receives.
         execution = _make_pipeline_execution()
         mock_service = MagicMock()
         mock_service.autograder_pipeline.return_value = MagicMock()
         mock_service.run_autograder.return_value = execution
         captured = {}
 
-        def capture_export(
-            score, include_feedback, feedback
+        def capture_pipeline(
+            template, include_feedback, feedback_mode
         ):  # pylint: disable=unused-argument
             captured["include_feedback"] = include_feedback
+            return MagicMock()
 
-        mock_service.export_results.side_effect = capture_export
+        mock_service.autograder_pipeline.side_effect = capture_pipeline
 
         argv = _make_argv(include_feedback=value) if value is not None else _make_argv()
         with patch.object(sys, "argv", argv), patch(
@@ -279,25 +271,8 @@ class TestHasFeedback:
     def test_none_returns_false(self):
         """Asserts include_feedback defaults to False when --include-feedback is not passed on the command line."""
         # No --include-feedback arg → defaults to False
-        execution = _make_pipeline_execution()
-        mock_service = MagicMock()
-        mock_service.autograder_pipeline.return_value = MagicMock()
-        mock_service.run_autograder.return_value = execution
-        captured = {}
-
-        def capture(
-            score, include_feedback, feedback
-        ):  # pylint: disable=unused-argument
-            captured["v"] = include_feedback
-
-        mock_service.export_results.side_effect = capture
-
-        with patch.object(sys, "argv", _make_argv()), patch(
-            "github_action.main.GithubActionService", return_value=mock_service
-        ):
-            run(main_module.main())
-
-        assert captured["v"] is False
+        result = self._invoke(None)
+        assert result is False
 
     def test_true_string_returns_true(self):
         """Asserts the lowercase string 'true' is correctly converted to the boolean True."""
@@ -320,8 +295,7 @@ class TestHasFeedback:
         assert result is False
 
     def test_invalid_value_raises_value_error(self):
-        """main() raises SystemExit(1) on invalid include_feedback value;
-        verify export_results is never reached."""
+        """main() raises SystemExit(1) on invalid include_feedback value."""
         execution = _make_pipeline_execution()
         mock_service = MagicMock()
         mock_service.autograder_pipeline.return_value = MagicMock()
@@ -334,11 +308,9 @@ class TestHasFeedback:
                 run(main_module.main())
 
         assert exc_info.value.code == 1
-        mock_service.export_results.assert_not_called()
 
     def test_invalid_value_raises_for_numeric_string(self):
-        """main() raises SystemExit(1) on numeric include_feedback value;
-        verify export_results is never reached."""
+        """main() raises SystemExit(1) on numeric include_feedback value."""
         execution = _make_pipeline_execution()
         mock_service = MagicMock()
         mock_service.autograder_pipeline.return_value = MagicMock()
@@ -351,7 +323,6 @@ class TestHasFeedback:
                 run(main_module.main())
 
         assert exc_info.value.code == 1
-        mock_service.export_results.assert_not_called()
 
 
 class TestGetSubmissionFiles:

--- a/tests/unit/pipeline/test_exporter_interface.py
+++ b/tests/unit/pipeline/test_exporter_interface.py
@@ -1,0 +1,88 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from typing import Optional
+
+from autograder.models.abstract.exporter import Exporter
+from autograder.steps.export_step import ExporterStep
+from autograder.services.upstash_driver import UpstashDriver
+from github_action.github_classroom_exporter import GithubClassroomExporter
+from autograder.steps.step_registry import StepRegistry
+from autograder.models.dataclass.step_result import StepName, StepStatus
+
+
+class MockExporter(Exporter):
+    def __init__(self):
+        self.called_with = None
+
+    def export(self, user_id: str, score: float, feedback: Optional[str] = None) -> None:
+        self.called_with = (user_id, score, feedback)
+
+
+class TestExporterInterface:
+    def test_exporter_step_calls_export(self):
+        """ExporterStep calls export() on the injected Exporter with correct arguments."""
+        mock_exporter = MockExporter()
+        step = ExporterStep(mock_exporter)
+
+        # Mock pipeline execution
+        mock_exec = MagicMock()
+        mock_exec.submission.user_id = "user123"
+        mock_exec.get_grade_step_result.return_value.final_score = 85.0
+        mock_exec.get_feedback.return_value = "Great work!"
+
+        result_exec = step._execute(mock_exec)
+
+        assert mock_exporter.called_with == ("user123", 85.0, "Great work!")
+        
+        # Verify result was added to pipeline
+        mock_exec.add_step_result.assert_called_once()
+        step_result = mock_exec.add_step_result.call_args[0][0]
+        assert step_result.step == StepName.EXPORTER
+        assert step_result.status == StepStatus.SUCCESS
+
+    def test_upstash_driver_export_delegates(self):
+        """UpstashDriver.export() delegates to set_score()."""
+        with patch("autograder.services.upstash_driver.Redis"):
+            driver = UpstashDriver()
+            driver.set_score = MagicMock()
+            
+            driver.export("user123", 95.0, "Optional feedback")
+            
+            driver.set_score.assert_called_once_with("user123", 95.0)
+
+    def test_github_classroom_exporter_export_delegates(self):
+        """GithubClassroomExporter.export() delegates to GithubActionService.export_results()."""
+        mock_service = MagicMock()
+        exporter = GithubClassroomExporter(mock_service)
+        
+        exporter.export("user123", 70.0, "Need improvement")
+        
+        mock_service.export_results.assert_called_once_with(70.0, True, "Need improvement")
+
+    def test_step_registry_build_exporter_none(self):
+        """StepRegistry._build_exporter() returns None when export_results=False."""
+        registry = StepRegistry({"export_results": False})
+        step = registry._build_exporter()
+        assert step is None
+
+    def test_step_registry_build_exporter_injected(self):
+        """StepRegistry._build_exporter() uses injected exporter when provided."""
+        mock_exporter = MagicMock(spec=Exporter)
+        registry = StepRegistry({"export_results": True, "exporter": mock_exporter})
+        
+        step = registry._build_exporter()
+        assert isinstance(step, ExporterStep)
+        assert step._exporter_service is mock_exporter
+
+    def test_step_registry_build_exporter_default(self):
+        """StepRegistry._build_exporter() creates UpstashDriver instance as default."""
+        with patch("autograder.steps.step_registry.UpstashDriver") as mock_driver_cls:
+            mock_driver = MagicMock(spec=UpstashDriver)
+            mock_driver_cls.return_value = mock_driver
+            
+            registry = StepRegistry({"export_results": True})
+            step = registry._build_exporter()
+            
+            assert isinstance(step, ExporterStep)
+            assert step._exporter_service is mock_driver
+            mock_driver_cls.assert_called_once()


### PR DESCRIPTION
This pull request formalizes the exporter plugin interface for the autograder pipeline, enabling pluggable export of grading results to external systems (such as Upstash Redis or GitHub Classroom). It introduces an abstract `Exporter` interface, refactors the pipeline to use this interface, and adapts existing exporters to conform. The pipeline and step registry are updated to support dependency injection of exporters, and the GitHub Action integration now uses a dedicated exporter class. Tests and documentation are updated to reflect these changes.

**Exporter Plugin System**

* Introduced an abstract `Exporter` interface in `autograder/models/abstract/exporter.py`, which defines a standard `export(user_id, score, feedback)` method for all exporters.
* Refactored `UpstashDriver` to implement the `Exporter` interface, and updated its export logic accordingly. [[1]](diffhunk://#diff-8e93dd904020fecfd3177078e6baa81bbfb3a1ee07f119a7b3265b30d7f02a84R4-R13) [[2]](diffhunk://#diff-8e93dd904020fecfd3177078e6baa81bbfb3a1ee07f119a7b3265b30d7f02a84R66-R69)
* Added a new `GithubClassroomExporter` class that implements the `Exporter` interface and wraps the existing GitHub Classroom export logic.

**Pipeline and Registry Refactoring**

* Updated `build_pipeline` and the `StepRegistry` to accept an `exporter` parameter, allowing injection of any exporter implementation. [[1]](diffhunk://#diff-36e41058491047f19d7f956a99f9ef4f31a27db40deb81495d1ceefda03e94ffR132) [[2]](diffhunk://#diff-36e41058491047f19d7f956a99f9ef4f31a27db40deb81495d1ceefda03e94ffR160) [[3]](diffhunk://#diff-a5d8fbabd661fa1d53f71b0d51583dd9aa1f6c215843bcf438ec330a342934faL77-R78)
* Modified `ExporterStep` to depend on the abstract `Exporter` interface, and to pass both score and feedback to the exporter. [[1]](diffhunk://#diff-a71cbc7918ce73467b4cd6d1a878d71301385e4dda0995ed6dd31b0fb63e21c3L12-R18) [[2]](diffhunk://#diff-a71cbc7918ce73467b4cd6d1a878d71301385e4dda0995ed6dd31b0fb63e21c3L30-R39)

**GitHub Action Integration**

* Updated `github_action_service.py` to instantiate and inject `GithubClassroomExporter` into the pipeline. [[1]](diffhunk://#diff-2ad908d1e3565fb013db26b6ea513b295b0176fdd902dac20ba24e0dfd2cfe67R6) [[2]](diffhunk://#diff-2ad908d1e3565fb013db26b6ea513b295b0176fdd902dac20ba24e0dfd2cfe67R216-R226)
* Removed direct calls to `export_results` from `main.py`; export now happens inside the pipeline via the exporter.

**Testing and Documentation**

* Updated unit tests to mock and verify the new exporter injection and usage patterns. [[1]](diffhunk://#diff-ece97969aa592d04e71d13fe8b3d7ff7ec76a66a1042210aaa2f4de45ed5b483L443-R448) [[2]](diffhunk://#diff-ece97969aa592d04e71d13fe8b3d7ff7ec76a66a1042210aaa2f4de45ed5b483R458-R459) [[3]](diffhunk://#diff-2901d079ffada9f130651aeec73d922d70506d4f277371c2addb53cae20c445aL81-R109) [[4]](diffhunk://#diff-2901d079ffada9f130651aeec73d922d70506d4f277371c2addb53cae20c445aL133) [[5]](diffhunk://#diff-2901d079ffada9f130651aeec73d922d70506d4f277371c2addb53cae20c445aL255-R261) [[6]](diffhunk://#diff-2901d079ffada9f130651aeec73d922d70506d4f277371c2addb53cae20c445aL282-R275) [[7]](diffhunk://#diff-2901d079ffada9f130651aeec73d922d70506d4f277371c2addb53cae20c445aL323-R298) [[8]](diffhunk://#diff-2901d079ffada9f130651aeec73d922d70506d4f277371c2addb53cae20c445aL337-R313) [[9]](diffhunk://#diff-2901d079ffada9f130651aeec73d922d70506d4f277371c2addb53cae20c445aL354)
* Marked the "Formalize exporter plugin" item as complete in `TECHNICAL_DEBT_ROADMAP.md`.