### PR TITLE
Add test weight and propagate to service

### DIFF
--- a/autograder/models/config/test.py
+++ b/autograder/models/config/test.py
@@ -21,8 +21,10 @@ class TestConfig(BaseModel):
     parameters: Optional[List[ParameterConfig]] = Field(
         None, description="Named parameters for the test function"
     )
+    weight: float = Field(100.0, ge=0, description="Weight of this test")
 
     model_config = {"extra": "forbid"}
+
 
     def get_args_list(self) -> List[Any]:
         """Convert named parameters to positional arguments list."""

--- a/autograder/models/config/test.py
+++ b/autograder/models/config/test.py
@@ -21,7 +21,8 @@ class TestConfig(BaseModel):
     parameters: Optional[List[ParameterConfig]] = Field(
         None, description="Named parameters for the test function"
     )
-    weight: float = Field(100.0, ge=0, description="Weight of this test")
+    weight: Optional[float] = Field(100.0, ge=0, description="Weight of this test")
+
 
     model_config = {"extra": "forbid"}
 

--- a/autograder/services/criteria_tree_service.py
+++ b/autograder/services/criteria_tree_service.py
@@ -103,8 +103,9 @@ class CriteriaTreeService:
             test_function,
             config.get_kwargs_dict() or {},
             file_target,
-            config.weight,
+            config.weight if config.weight is not None else 100.0,
         )
+
 
 
         return test

--- a/autograder/services/criteria_tree_service.py
+++ b/autograder/services/criteria_tree_service.py
@@ -103,7 +103,9 @@ class CriteriaTreeService:
             test_function,
             config.get_kwargs_dict() or {},
             file_target,
+            config.weight,
         )
+
 
         return test
 

--- a/autograder/services/grader_service.py
+++ b/autograder/services/grader_service.py
@@ -238,7 +238,9 @@ class GraderService:
             score=test_result.score,
             report=test_result.report,
             parameters=test_result.parameters,
+            weight=test.weight,
         )
+
 
     def get_file_target(
         self,


### PR DESCRIPTION
This pull request introduces support for assigning a weight to each test in the autograder configuration, allowing for more granular scoring or prioritization of tests. The main changes add a `weight` field to the `TestConfig` model and ensure this value is passed through to where tests are constructed.

**Test configuration and scoring improvements:**

* Added a `weight` field (defaulting to 100.0, must be non-negative) to the `TestConfig` model in `autograder/models/config/test.py`, allowing each test to specify its relative importance.
* Updated the test parsing logic in `autograder/services/criteria_tree_service.py` to pass the new `weight` field when constructing a test node, ensuring the weight is used in downstream processing.