### PR TITLE
feat: Deterministic container naming for traceability #265

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,5 +1,5 @@
 # 1. Use an official Python image as the base
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 # 2. Set environment variables
 ENV PYTHONUNBUFFERED=1

--- a/docs/architecture/sandbox_manager.md
+++ b/docs/architecture/sandbox_manager.md
@@ -220,6 +220,10 @@ make build-sandboxes
 
 Each container is created with:
 
+- **Name:** Deterministic format `ag-sbx-{lang}-{pool8}-{seq4}` (e.g., `ag-sbx-py-a1b2c3d4-0001`)
+  - `lang`: language key (`python`, `java`, `node`, `cpp`, `c`)
+  - `pool8`: first 8 chars of the pool's UUID
+  - `seq4`: zero-padded per-pool creation sequence
 - **Memory limit:** 128 MB (no swap)
 - **CPU limit:** 0.5 CPU cores
 - **Process limit:** 64 PIDs

--- a/sandbox_manager/language_pool.py
+++ b/sandbox_manager/language_pool.py
@@ -38,7 +38,7 @@ class LanguagePool:
         # Only blocks for this pool, allowing concurrent access to different pools
         self.lock = threading.Lock()
 
-        print(f"[{self.language}] 🚀 POOL INITIALIZED - pool_size: {config.pool_size}, scale_limit: {config.scale_limit}, pool_id: {self.pool_id[:8]}")
+        print(f"[{self.language}] POOL INITIALIZED - pool_size: {config.pool_size}, scale_limit: {config.scale_limit}, pool_id: {self.pool_id[:8]}")
 
     def acquire(self) -> SandboxContainer:
         with self.lock:
@@ -46,38 +46,38 @@ class LanguagePool:
             current_idle = len(self.idle_sandboxes)
             current_active = len(self.active_sandboxes)
 
-            print(f"[{self.language}] 🔍 ACQUIRE REQUEST - idle: {current_idle}, active: {current_active}, total: {current_total}/{self.config.scale_limit}")
+            print(f"[{self.language}] ACQUIRE REQUEST - idle: {current_idle}, active: {current_active}, total: {current_total}/{self.config.scale_limit}")
 
             # Try to get an idle sandbox first
             if self.idle_sandboxes:
                 sandbox = self.idle_sandboxes.popleft()
                 sandbox.pickup() # Update state and timestamp
                 self.active_sandboxes.add(sandbox)
-                print(f"[{self.language}] ✅ ACQUIRED from idle pool - sandbox_id: {sandbox.container_ref.id[:12]}")
-                print(f"[{self.language}] 📊 AFTER ACQUIRE - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes)}")
+                print(f"[{self.language}] ACQUIRED from idle pool - sandbox_id: {sandbox.container_ref.id[:12]}")
+                print(f"[{self.language}] AFTER ACQUIRE - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes)}")
                 return sandbox
 
             # No idle sandboxes - check if we can scale up
             if current_total < self.config.scale_limit:
                 # We can create a new sandbox on-demand
-                print(f"[{self.language}] ⚠️ NO IDLE SANDBOXES - Attempting scale-up...")
-                print(f"[{self.language}] 🔄 SCALING UP: creating sandbox #{current_total + 1} (limit: {self.config.scale_limit})")
+                print(f"[{self.language}] NO IDLE SANDBOXES - Attempting scale-up...")
+                print(f"[{self.language}] SCALING UP: creating sandbox #{current_total + 1} (limit: {self.config.scale_limit})")
                 try:
                     new_sandbox = self._create_sandbox()
                     new_sandbox.pickup()
                     self.active_sandboxes.add(new_sandbox)
-                    print(f"[{self.language}] ✅ SCALE-UP SUCCESS - created sandbox_id: {new_sandbox.container_ref.id[:12]}")
-                    print(f"[{self.language}] 📊 AFTER SCALE-UP - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes)}, total: {len(self.active_sandboxes) + len(self.idle_sandboxes)}/{self.config.scale_limit}")
+                    print(f"[{self.language}] SCALE-UP SUCCESS - created sandbox_id: {new_sandbox.container_ref.id[:12]}")
+                    print(f"[{self.language}] AFTER SCALE-UP - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes)}, total: {len(self.active_sandboxes) + len(self.idle_sandboxes)}/{self.config.scale_limit}")
                     return new_sandbox
                 except Exception as e:
-                    print(f"[{self.language}] ❌ SCALE-UP FAILED - Error: {e}")
+                    print(f"[{self.language}] SCALE-UP FAILED - Error: {e}")
                     raise ValueError(f"Failed to create sandbox for language {self.language}: {e}")
 
             # At scale limit and all busy - fail
-            print(f"[{self.language}] 🚨 BOTTLENECK DETECTED!")
-            print(f"[{self.language}] 🚨 All {current_total} sandboxes are BUSY (idle: 0, active: {current_active})")
-            print(f"[{self.language}] 🚨 Scale limit reached: {self.config.scale_limit}")
-            print(f"[{self.language}] 🚨 Cannot scale further - BLOCKING REQUEST")
+            print(f"[{self.language}] BOTTLENECK DETECTED!")
+            print(f"[{self.language}] All {current_total} sandboxes are BUSY (idle: 0, active: {current_active})")
+            print(f"[{self.language}] Scale limit reached: {self.config.scale_limit}")
+            print(f"[{self.language}] Cannot scale further - BLOCKING REQUEST")
             raise ValueError(
                 f"No idle sandboxes available for language {self.language}. "
                 f"All {current_total} sandboxes are busy (scale_limit: {self.config.scale_limit})"
@@ -92,24 +92,24 @@ class LanguagePool:
                 # Check if we should reuse or destroy
                 current_total = len(self.active_sandboxes) + len(self.idle_sandboxes)
 
-                print(f"[{self.language}] 🔓 RELEASE - sandbox_id: {sandbox_id}")
-                print(f"[{self.language}] 📊 BEFORE RELEASE - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes) + 1}, total: {current_total + 1}/{self.config.scale_limit}")
+                print(f"[{self.language}] RELEASE - sandbox_id: {sandbox_id}")
+                print(f"[{self.language}] BEFORE RELEASE - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes) + 1}, total: {current_total + 1}/{self.config.scale_limit}")
 
                 # Reuse if below scale_limit, otherwise destroy to scale down
                 if current_total <= self.config.scale_limit:
                     # Return to idle pool for reuse
                     sandbox.last_updated = datetime.now()  # Reset timestamp
                     self.idle_sandboxes.append(sandbox)
-                    print(f"[{self.language}] ♻️ REUSE - returned to idle pool")
-                    print(f"[{self.language}] 📊 AFTER RELEASE - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes)}, total: {current_total}/{self.config.scale_limit}")
+                    print(f"[{self.language}] REUSE - returned to idle pool")
+                    print(f"[{self.language}] AFTER RELEASE - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes)}, total: {current_total}/{self.config.scale_limit}")
                 else:
                     # Above scale_limit, destroy to scale down
                     try:
                         self._destroy_sandbox(sandbox)
-                        print(f"[{self.language}] 🔽 SCALE-DOWN - destroyed sandbox_id: {sandbox_id}")
-                        print(f"[{self.language}] 📊 AFTER SCALE-DOWN - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes)}, total: {current_total - 1}/{self.config.scale_limit}")
+                        print(f"[{self.language}] SCALE-DOWN - destroyed sandbox_id: {sandbox_id}")
+                        print(f"[{self.language}] AFTER SCALE-DOWN - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes)}, total: {current_total - 1}/{self.config.scale_limit}")
                     except Exception as e:
-                        print(f"[{self.language}] ❌ Error destroying sandbox during scale-down: {e}")
+                        print(f"[{self.language}] Error destroying sandbox during scale-down: {e}")
             else:
                 raise ValueError("Sandbox not found in active sandboxes")
 
@@ -151,19 +151,19 @@ class LanguagePool:
             needed = self.config.pool_size - current_idle
 
             if needed > 0:
-                print(f"[{self.language}] 🔄 REPLENISH CHECK - idle: {current_idle}/{self.config.pool_size} (need {needed} more), total: {current_total_sandboxes}/{self.config.scale_limit}")
+                print(f"[{self.language}] REPLENISH CHECK - idle: {current_idle}/{self.config.pool_size} (need {needed} more), total: {current_total_sandboxes}/{self.config.scale_limit}")
 
             # Maintain minimum pool_size of idle sandboxes
             while len(self.idle_sandboxes) < self.config.pool_size and current_total_sandboxes < self.config.scale_limit:
                 try:
-                    print(f"[{self.language}] ➕ REPLENISH: Creating sandbox #{current_total_sandboxes + 1}...")
+                    print(f"[{self.language}] REPLENISH: Creating sandbox #{current_total_sandboxes + 1}...")
                     new_sandbox = self._create_sandbox()
                     self.idle_sandboxes.append(new_sandbox)
                     current_total_sandboxes += 1
-                    print(f"[{self.language}] ✅ REPLENISH SUCCESS - sandbox_id: {new_sandbox.container_ref.id[:12]}")
-                    print(f"[{self.language}] 📊 AFTER REPLENISH - idle: {len(self.idle_sandboxes)}/{self.config.pool_size}, total: {current_total_sandboxes}/{self.config.scale_limit}")
+                    print(f"[{self.language}] REPLENISH SUCCESS - sandbox_id: {new_sandbox.container_ref.id[:12]}")
+                    print(f"[{self.language}] AFTER REPLENISH - idle: {len(self.idle_sandboxes)}/{self.config.pool_size}, total: {current_total_sandboxes}/{self.config.scale_limit}")
                 except Exception as e:
-                    print(f"[{self.language}] ❌ REPLENISH FAILED - Error: {e}")
+                    print(f"[{self.language}] REPLENISH FAILED - Error: {e}")
                     break
 
     def check_ttls(self):
@@ -203,6 +203,7 @@ class LanguagePool:
         self.replenish()
 
         # Periodic stats logging every ~10 calls (assuming 1 second intervals = ~10 seconds)
+        # Only logs when there's active operations
         if not hasattr(self, '_monitor_counter'):
             self._monitor_counter = 0
 
@@ -213,12 +214,13 @@ class LanguagePool:
             utilization = stats['utilization']
 
             # Log with appropriate warning level based on utilization
+            # Only log stats if there are active operations or high utilization
             if utilization >= 90:
-                print(f"[{self.language}] 🚨 HIGH LOAD - idle: {stats['idle']}, active: {stats['active']}, total: {stats['total']}/{stats['scale_limit']}, utilization: {utilization:.1f}%")
+                print(f"[{self.language}] HIGH LOAD - idle: {stats['idle']}, active: {stats['active']}, total: {stats['total']}/{stats['scale_limit']}, utilization: {utilization:.1f}%")
             elif utilization >= 70:
-                print(f"[{self.language}] ⚠️ MODERATE LOAD - idle: {stats['idle']}, active: {stats['active']}, total: {stats['total']}/{stats['scale_limit']}, utilization: {utilization:.1f}%")
-            elif stats['total'] > 0:
-                print(f"[{self.language}] 📊 STATS - idle: {stats['idle']}, active: {stats['active']}, total: {stats['total']}/{stats['scale_limit']}, utilization: {utilization:.1f}%")
+                print(f"[{self.language}] MODERATE LOAD - idle: {stats['idle']}, active: {stats['active']}, total: {stats['total']}/{stats['scale_limit']}, utilization: {utilization:.1f}%")
+            elif stats['active'] > 0:
+                print(f"[{self.language}] STATS - idle: {stats['idle']}, active: {stats['active']}, total: {stats['total']}/{stats['scale_limit']}, utilization: {utilization:.1f}%")
 
     def get_stats(self) -> dict:
         """
@@ -243,7 +245,7 @@ class LanguagePool:
         Containers are kept alive with 'sleep infinity' to allow exec commands.
         """
         container_name = self._build_container_name()
-        print(f"[{self.language}] 🏗️ CREATE SANDBOX - Starting container creation ({container_name})...")
+        print(f"[{self.language}] CREATE SANDBOX - Starting container creation ({container_name})...")
 
         # Container labels for tracking and orphan cleanup
         labels = {
@@ -256,7 +258,7 @@ class LanguagePool:
 
         # Try to use gVisor runtime for enhanced security, fall back to default if not available
         try:
-            print(f"[{self.language}] 🔒 Attempting to create with gVisor runtime (runsc)...")
+            print(f"[{self.language}] Attempting to create with gVisor runtime (runsc)...")
             container = self.client.containers.run(
                 image=self.language.image,
                 name=container_name,
@@ -278,11 +280,11 @@ class LanguagePool:
                 ],
                 labels=labels
             )
-            print(f"[{self.language}] ✅ Container created with gVisor - {container_name} ({container.id[:12]})")
+            print(f"[{self.language}] Container created with gVisor - {container_name} ({container.id[:12]})")
         except Exception as e:
             # If gVisor is not available, use default runtime with same constraints
             if "unknown or invalid runtime name" in str(e).lower() or "runsc" in str(e).lower():
-                print(f"[{self.language}] ⚠️ gVisor runtime not available, falling back to default runtime")
+                print(f"[{self.language}] gVisor runtime not available, falling back to default runtime")
                 container = self.client.containers.run(
                     image=self.language.image,
                     name=container_name,
@@ -295,7 +297,7 @@ class LanguagePool:
                     pids_limit=64,
                     tmpfs={
                         '/tmp': 'rw,size=32m,noexec',
-                        '/app': 'rw,size=64m,exec'
+                        # Note: /app intentionally NOT in tmpfs — see above.
                     },
                     network_mode="none",
                     cap_drop=["ALL"],
@@ -304,14 +306,14 @@ class LanguagePool:
                     ],
                     labels=labels
                 )
-                print(f"[{self.language}] ✅ Container created with default runtime - {container_name} ({container.id[:12]})")
+                print(f"[{self.language}] Container created with default runtime - {container_name} ({container.id[:12]})")
             else:
                 # Re-raise if it's a different error
-                print(f"[{self.language}] ❌ Container creation failed: {e}")
+                print(f"[{self.language}] Container creation failed: {e}")
                 raise
 
         sandbox = SandboxContainer(language=self.language, container_ref=container)
-        print(f"[{self.language}] 🎉 SANDBOX CREATED SUCCESSFULLY - {container_name} ({container.id[:12]})")
+        print(f"[{self.language}] SANDBOX CREATED SUCCESSFULLY - {container_name} ({container.id[:12]})")
         return sandbox
 
     def _build_container_name(self) -> str:
@@ -331,27 +333,27 @@ class LanguagePool:
             if sandbox in self.active_sandboxes:
                 sandbox_id = sandbox.container_ref.id[:12]
                 self.active_sandboxes.remove(sandbox)
-                print(f"[{self.language}] 🔓 REMOVE FROM ACTIVE - sandbox_id: {sandbox_id}")
-                print(f"[{self.language}] 📊 BEFORE DESTROY - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes) + 1}, total: {len(self.active_sandboxes) + len(self.idle_sandboxes) + 1}/{self.config.scale_limit}")
+                print(f"[{self.language}] REMOVE FROM ACTIVE - sandbox_id: {sandbox_id}")
+                print(f"[{self.language}] BEFORE DESTROY - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes) + 1}, total: {len(self.active_sandboxes) + len(self.idle_sandboxes) + 1}/{self.config.scale_limit}")
             else:
                 raise ValueError("Sandbox not found in active sandboxes")
 
         # Destroy outside the lock
         self._destroy_sandbox(sandbox)
-        print(f"[{self.language}] 📊 AFTER DESTROY - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes)}, total: {len(self.active_sandboxes) + len(self.idle_sandboxes)}/{self.config.scale_limit}")
+        print(f"[{self.language}] AFTER DESTROY - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes)}, total: {len(self.active_sandboxes) + len(self.idle_sandboxes)}/{self.config.scale_limit}")
 
         # Replenish pool to maintain minimum size
         self.replenish()
 
     def _destroy_sandbox(self, sandbox: SandboxContainer):
         sandbox_id = sandbox.container_ref.id[:12]
-        print(f"[{self.language}] 🗑️ DESTROY SANDBOX - container_id: {sandbox_id}")
+        print(f"[{self.language}] DESTROY SANDBOX - container_id: {sandbox_id}")
         try:
             sandbox.container_ref.stop(timeout=1)
             sandbox.container_ref.remove()
-            print(f"[{self.language}] ✅ SANDBOX DESTROYED - container_id: {sandbox_id}")
+            print(f"[{self.language}] SANDBOX DESTROYED - container_id: {sandbox_id}")
         except Exception as e:
-            print(f"[{self.language}] ❌ Error destroying sandbox {sandbox_id}: {e}")
+            print(f"[{self.language}] Error destroying sandbox {sandbox_id}: {e}")
 
     def shutdown(self):
         """

--- a/sandbox_manager/language_pool.py
+++ b/sandbox_manager/language_pool.py
@@ -30,6 +30,7 @@ class LanguagePool:
         self.config = config
         self.client = client
         self.pool_id = str(uuid.uuid4())  # Unique identifier for this pool instance
+        self._sandbox_seq = 0  # Per-pool creation sequence counter
 
         self.idle_sandboxes : deque[SandboxContainer] = deque()
         self.active_sandboxes : Set[SandboxContainer] = set()
@@ -37,7 +38,7 @@ class LanguagePool:
         # Only blocks for this pool, allowing concurrent access to different pools
         self.lock = threading.Lock()
 
-        print(f"[{self.language}] POOL INITIALIZED - pool_size: {config.pool_size}, scale_limit: {config.scale_limit}, pool_id: {self.pool_id[:8]}")
+        print(f"[{self.language}] 🚀 POOL INITIALIZED - pool_size: {config.pool_size}, scale_limit: {config.scale_limit}, pool_id: {self.pool_id[:8]}")
 
     def acquire(self) -> SandboxContainer:
         with self.lock:
@@ -45,38 +46,38 @@ class LanguagePool:
             current_idle = len(self.idle_sandboxes)
             current_active = len(self.active_sandboxes)
 
-            print(f"[{self.language}] ACQUIRE REQUEST - idle: {current_idle}, active: {current_active}, total: {current_total}/{self.config.scale_limit}")
+            print(f"[{self.language}] 🔍 ACQUIRE REQUEST - idle: {current_idle}, active: {current_active}, total: {current_total}/{self.config.scale_limit}")
 
             # Try to get an idle sandbox first
             if self.idle_sandboxes:
                 sandbox = self.idle_sandboxes.popleft()
                 sandbox.pickup() # Update state and timestamp
                 self.active_sandboxes.add(sandbox)
-                print(f"[{self.language}] ACQUIRED from idle pool - sandbox_id: {sandbox.container_ref.id[:12]}")
-                print(f"[{self.language}] AFTER ACQUIRE - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes)}")
+                print(f"[{self.language}] ✅ ACQUIRED from idle pool - sandbox_id: {sandbox.container_ref.id[:12]}")
+                print(f"[{self.language}] 📊 AFTER ACQUIRE - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes)}")
                 return sandbox
 
             # No idle sandboxes - check if we can scale up
             if current_total < self.config.scale_limit:
                 # We can create a new sandbox on-demand
-                print(f"[{self.language}] NO IDLE SANDBOXES - Attempting scale-up...")
-                print(f"[{self.language}] SCALING UP: creating sandbox #{current_total + 1} (limit: {self.config.scale_limit})")
+                print(f"[{self.language}] ⚠️ NO IDLE SANDBOXES - Attempting scale-up...")
+                print(f"[{self.language}] 🔄 SCALING UP: creating sandbox #{current_total + 1} (limit: {self.config.scale_limit})")
                 try:
                     new_sandbox = self._create_sandbox()
                     new_sandbox.pickup()
                     self.active_sandboxes.add(new_sandbox)
-                    print(f"[{self.language}] SCALE-UP SUCCESS - created sandbox_id: {new_sandbox.container_ref.id[:12]}")
-                    print(f"[{self.language}] AFTER SCALE-UP - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes)}, total: {len(self.active_sandboxes) + len(self.idle_sandboxes)}/{self.config.scale_limit}")
+                    print(f"[{self.language}] ✅ SCALE-UP SUCCESS - created sandbox_id: {new_sandbox.container_ref.id[:12]}")
+                    print(f"[{self.language}] 📊 AFTER SCALE-UP - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes)}, total: {len(self.active_sandboxes) + len(self.idle_sandboxes)}/{self.config.scale_limit}")
                     return new_sandbox
                 except Exception as e:
-                    print(f"[{self.language}] SCALE-UP FAILED - Error: {e}")
+                    print(f"[{self.language}] ❌ SCALE-UP FAILED - Error: {e}")
                     raise ValueError(f"Failed to create sandbox for language {self.language}: {e}")
 
             # At scale limit and all busy - fail
-            print(f"[{self.language}] BOTTLENECK DETECTED!")
-            print(f"[{self.language}] All {current_total} sandboxes are BUSY (idle: 0, active: {current_active})")
-            print(f"[{self.language}] Scale limit reached: {self.config.scale_limit}")
-            print(f"[{self.language}] Cannot scale further - BLOCKING REQUEST")
+            print(f"[{self.language}] 🚨 BOTTLENECK DETECTED!")
+            print(f"[{self.language}] 🚨 All {current_total} sandboxes are BUSY (idle: 0, active: {current_active})")
+            print(f"[{self.language}] 🚨 Scale limit reached: {self.config.scale_limit}")
+            print(f"[{self.language}] 🚨 Cannot scale further - BLOCKING REQUEST")
             raise ValueError(
                 f"No idle sandboxes available for language {self.language}. "
                 f"All {current_total} sandboxes are busy (scale_limit: {self.config.scale_limit})"
@@ -91,24 +92,24 @@ class LanguagePool:
                 # Check if we should reuse or destroy
                 current_total = len(self.active_sandboxes) + len(self.idle_sandboxes)
 
-                print(f"[{self.language}] RELEASE - sandbox_id: {sandbox_id}")
-                print(f"[{self.language}] BEFORE RELEASE - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes) + 1}, total: {current_total + 1}/{self.config.scale_limit}")
+                print(f"[{self.language}] 🔓 RELEASE - sandbox_id: {sandbox_id}")
+                print(f"[{self.language}] 📊 BEFORE RELEASE - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes) + 1}, total: {current_total + 1}/{self.config.scale_limit}")
 
                 # Reuse if below scale_limit, otherwise destroy to scale down
                 if current_total <= self.config.scale_limit:
                     # Return to idle pool for reuse
                     sandbox.last_updated = datetime.now()  # Reset timestamp
                     self.idle_sandboxes.append(sandbox)
-                    print(f"[{self.language}] REUSE - returned to idle pool")
-                    print(f"[{self.language}] AFTER RELEASE - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes)}, total: {current_total}/{self.config.scale_limit}")
+                    print(f"[{self.language}] ♻️ REUSE - returned to idle pool")
+                    print(f"[{self.language}] 📊 AFTER RELEASE - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes)}, total: {current_total}/{self.config.scale_limit}")
                 else:
                     # Above scale_limit, destroy to scale down
                     try:
                         self._destroy_sandbox(sandbox)
-                        print(f"[{self.language}] SCALE-DOWN - destroyed sandbox_id: {sandbox_id}")
-                        print(f"[{self.language}] AFTER SCALE-DOWN - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes)}, total: {current_total - 1}/{self.config.scale_limit}")
+                        print(f"[{self.language}] 🔽 SCALE-DOWN - destroyed sandbox_id: {sandbox_id}")
+                        print(f"[{self.language}] 📊 AFTER SCALE-DOWN - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes)}, total: {current_total - 1}/{self.config.scale_limit}")
                     except Exception as e:
-                        print(f"[{self.language}] Error destroying sandbox during scale-down: {e}")
+                        print(f"[{self.language}] ❌ Error destroying sandbox during scale-down: {e}")
             else:
                 raise ValueError("Sandbox not found in active sandboxes")
 
@@ -150,19 +151,19 @@ class LanguagePool:
             needed = self.config.pool_size - current_idle
 
             if needed > 0:
-                print(f"[{self.language}] REPLENISH CHECK - idle: {current_idle}/{self.config.pool_size} (need {needed} more), total: {current_total_sandboxes}/{self.config.scale_limit}")
+                print(f"[{self.language}] 🔄 REPLENISH CHECK - idle: {current_idle}/{self.config.pool_size} (need {needed} more), total: {current_total_sandboxes}/{self.config.scale_limit}")
 
             # Maintain minimum pool_size of idle sandboxes
             while len(self.idle_sandboxes) < self.config.pool_size and current_total_sandboxes < self.config.scale_limit:
                 try:
-                    print(f"[{self.language}] REPLENISH: Creating sandbox #{current_total_sandboxes + 1}...")
+                    print(f"[{self.language}] ➕ REPLENISH: Creating sandbox #{current_total_sandboxes + 1}...")
                     new_sandbox = self._create_sandbox()
                     self.idle_sandboxes.append(new_sandbox)
                     current_total_sandboxes += 1
-                    print(f"[{self.language}] REPLENISH SUCCESS - sandbox_id: {new_sandbox.container_ref.id[:12]}")
-                    print(f"[{self.language}] AFTER REPLENISH - idle: {len(self.idle_sandboxes)}/{self.config.pool_size}, total: {current_total_sandboxes}/{self.config.scale_limit}")
+                    print(f"[{self.language}] ✅ REPLENISH SUCCESS - sandbox_id: {new_sandbox.container_ref.id[:12]}")
+                    print(f"[{self.language}] 📊 AFTER REPLENISH - idle: {len(self.idle_sandboxes)}/{self.config.pool_size}, total: {current_total_sandboxes}/{self.config.scale_limit}")
                 except Exception as e:
-                    print(f"[{self.language}] REPLENISH FAILED - Error: {e}")
+                    print(f"[{self.language}] ❌ REPLENISH FAILED - Error: {e}")
                     break
 
     def check_ttls(self):
@@ -202,7 +203,6 @@ class LanguagePool:
         self.replenish()
 
         # Periodic stats logging every ~10 calls (assuming 1 second intervals = ~10 seconds)
-        # Only logs when there's active operations
         if not hasattr(self, '_monitor_counter'):
             self._monitor_counter = 0
 
@@ -213,13 +213,12 @@ class LanguagePool:
             utilization = stats['utilization']
 
             # Log with appropriate warning level based on utilization
-            # Only log stats if there are active operations or high utilization
             if utilization >= 90:
-                print(f"[{self.language}] HIGH LOAD - idle: {stats['idle']}, active: {stats['active']}, total: {stats['total']}/{stats['scale_limit']}, utilization: {utilization:.1f}%")
+                print(f"[{self.language}] 🚨 HIGH LOAD - idle: {stats['idle']}, active: {stats['active']}, total: {stats['total']}/{stats['scale_limit']}, utilization: {utilization:.1f}%")
             elif utilization >= 70:
-                print(f"[{self.language}] MODERATE LOAD - idle: {stats['idle']}, active: {stats['active']}, total: {stats['total']}/{stats['scale_limit']}, utilization: {utilization:.1f}%")
-            elif stats['active'] > 0:
-                print(f"[{self.language}] STATS - idle: {stats['idle']}, active: {stats['active']}, total: {stats['total']}/{stats['scale_limit']}, utilization: {utilization:.1f}%")
+                print(f"[{self.language}] ⚠️ MODERATE LOAD - idle: {stats['idle']}, active: {stats['active']}, total: {stats['total']}/{stats['scale_limit']}, utilization: {utilization:.1f}%")
+            elif stats['total'] > 0:
+                print(f"[{self.language}] 📊 STATS - idle: {stats['idle']}, active: {stats['active']}, total: {stats['total']}/{stats['scale_limit']}, utilization: {utilization:.1f}%")
 
     def get_stats(self) -> dict:
         """
@@ -243,7 +242,8 @@ class LanguagePool:
 
         Containers are kept alive with 'sleep infinity' to allow exec commands.
         """
-        print(f"[{self.language}] CREATE SANDBOX - Starting container creation...")
+        container_name = self._build_container_name()
+        print(f"[{self.language}] 🏗️ CREATE SANDBOX - Starting container creation ({container_name})...")
 
         # Container labels for tracking and orphan cleanup
         labels = {
@@ -256,9 +256,10 @@ class LanguagePool:
 
         # Try to use gVisor runtime for enhanced security, fall back to default if not available
         try:
-            print(f"[{self.language}] Attempting to create with gVisor runtime (runsc)...")
+            print(f"[{self.language}] 🔒 Attempting to create with gVisor runtime (runsc)...")
             container = self.client.containers.run(
                 image=self.language.image,
+                name=container_name,
                 detach=True,
                 command="sleep infinity",  # Keep container alive for exec commands
                 runtime="runsc",  # gVisor runtime for enhanced isolation
@@ -277,13 +278,14 @@ class LanguagePool:
                 ],
                 labels=labels
             )
-            print(f"[{self.language}] Container created with gVisor - container_id: {container.id[:12]}")
+            print(f"[{self.language}] ✅ Container created with gVisor - {container_name} ({container.id[:12]})")
         except Exception as e:
             # If gVisor is not available, use default runtime with same constraints
             if "unknown or invalid runtime name" in str(e).lower() or "runsc" in str(e).lower():
-                print(f"[{self.language}] gVisor runtime not available, falling back to default runtime")
+                print(f"[{self.language}] ⚠️ gVisor runtime not available, falling back to default runtime")
                 container = self.client.containers.run(
                     image=self.language.image,
+                    name=container_name,
                     detach=True,
                     command="sleep infinity",  # Keep container alive for exec commands
                     # No runtime specified = default runc
@@ -293,7 +295,7 @@ class LanguagePool:
                     pids_limit=64,
                     tmpfs={
                         '/tmp': 'rw,size=32m,noexec',
-                        # Note: /app intentionally NOT in tmpfs — see above.
+                        '/app': 'rw,size=64m,exec'
                     },
                     network_mode="none",
                     cap_drop=["ALL"],
@@ -302,15 +304,20 @@ class LanguagePool:
                     ],
                     labels=labels
                 )
-                print(f"[{self.language}] Container created with default runtime - container_id: {container.id[:12]}")
+                print(f"[{self.language}] ✅ Container created with default runtime - {container_name} ({container.id[:12]})")
             else:
                 # Re-raise if it's a different error
-                print(f"[{self.language}] Container creation failed: {e}")
+                print(f"[{self.language}] ❌ Container creation failed: {e}")
                 raise
 
         sandbox = SandboxContainer(language=self.language, container_ref=container)
-        print(f"[{self.language}] SANDBOX CREATED SUCCESSFULLY - container_id: {container.id[:12]}")
+        print(f"[{self.language}] 🎉 SANDBOX CREATED SUCCESSFULLY - {container_name} ({container.id[:12]})")
         return sandbox
+
+    def _build_container_name(self) -> str:
+        """Build deterministic container name: ag-sbx-{lang}-{pool8}-{seq4}"""
+        self._sandbox_seq += 1
+        return f"ag-sbx-{self.language.value}-{self.pool_id[:8]}-{self._sandbox_seq:04d}"
 
     def destroy_sandbox(self, sandbox: SandboxContainer) -> None:
         """
@@ -324,27 +331,27 @@ class LanguagePool:
             if sandbox in self.active_sandboxes:
                 sandbox_id = sandbox.container_ref.id[:12]
                 self.active_sandboxes.remove(sandbox)
-                print(f"[{self.language}] REMOVE FROM ACTIVE - sandbox_id: {sandbox_id}")
-                print(f"[{self.language}] BEFORE DESTROY - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes) + 1}, total: {len(self.active_sandboxes) + len(self.idle_sandboxes) + 1}/{self.config.scale_limit}")
+                print(f"[{self.language}] 🔓 REMOVE FROM ACTIVE - sandbox_id: {sandbox_id}")
+                print(f"[{self.language}] 📊 BEFORE DESTROY - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes) + 1}, total: {len(self.active_sandboxes) + len(self.idle_sandboxes) + 1}/{self.config.scale_limit}")
             else:
                 raise ValueError("Sandbox not found in active sandboxes")
 
         # Destroy outside the lock
         self._destroy_sandbox(sandbox)
-        print(f"[{self.language}] AFTER DESTROY - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes)}, total: {len(self.active_sandboxes) + len(self.idle_sandboxes)}/{self.config.scale_limit}")
+        print(f"[{self.language}] 📊 AFTER DESTROY - idle: {len(self.idle_sandboxes)}, active: {len(self.active_sandboxes)}, total: {len(self.active_sandboxes) + len(self.idle_sandboxes)}/{self.config.scale_limit}")
 
         # Replenish pool to maintain minimum size
         self.replenish()
 
     def _destroy_sandbox(self, sandbox: SandboxContainer):
         sandbox_id = sandbox.container_ref.id[:12]
-        print(f"[{self.language}] DESTROY SANDBOX - container_id: {sandbox_id}")
+        print(f"[{self.language}] 🗑️ DESTROY SANDBOX - container_id: {sandbox_id}")
         try:
             sandbox.container_ref.stop(timeout=1)
             sandbox.container_ref.remove()
-            print(f"[{self.language}] SANDBOX DESTROYED - container_id: {sandbox_id}")
+            print(f"[{self.language}] ✅ SANDBOX DESTROYED - container_id: {sandbox_id}")
         except Exception as e:
-            print(f"[{self.language}] Error destroying sandbox {sandbox_id}: {e}")
+            print(f"[{self.language}] ❌ Error destroying sandbox {sandbox_id}: {e}")
 
     def shutdown(self):
         """

--- a/sandbox_manager/manager.py
+++ b/sandbox_manager/manager.py
@@ -57,10 +57,10 @@ def _cleanup_orphaned_containers(client: docker.DockerClient):
             print(f"[SandboxManager] Found {len(orphaned_containers)} orphaned container(s)")
             for container in orphaned_containers:
                 try:
-                    print(f"[SandboxManager] Removing orphaned container {container.id[:12]}...")
+                    print(f"[SandboxManager] Removing orphaned container {container.name} ({container.id[:12]})...")
                     container.remove(force=True)
                 except Exception as e:
-                    print(f"[SandboxManager] Failed to remove orphaned container {container.id[:12]}: {e}")
+                    print(f"[SandboxManager] Failed to remove orphaned container {container.name} ({container.id[:12]}): {e}")
             print(f"[SandboxManager] Orphan cleanup complete")
         else:
             print("[SandboxManager] No orphaned containers found")

--- a/sandbox_manager/sandbox_container.py
+++ b/sandbox_manager/sandbox_container.py
@@ -363,4 +363,5 @@ class SandboxContainer:
             raise requests.RequestException(f"HTTP {method} request to {url} failed: {str(e)}")
 
     def __repr__(self):
-        return f"<SandboxContainer lang={self.language.value} state={self.state.value} id={self.container_ref.id[:12]}>"
+        name = self.container_ref.name or "unnamed"
+        return f"<SandboxContainer lang={self.language.value} state={self.state.value} name={name} id={self.container_ref.id[:12]}>"

--- a/tests/integration/test_sandbox_lifecycle.py
+++ b/tests/integration/test_sandbox_lifecycle.py
@@ -175,6 +175,29 @@ class TestSandboxLifecycle:
             assert "autograder.sandbox.pool_id" in labels
             assert "autograder.sandbox.created_at" in labels
 
+    def test_deterministic_container_naming(self):
+        """Test that sandbox containers have deterministic names following ag-sbx-{lang}-{pool8}-{seq4}."""
+        import re
+        with self.manager.acquire_sandbox(Language.PYTHON) as sandbox:
+            sandbox.container_ref.reload()
+            name = sandbox.container_ref.name
+            # Must match ag-sbx-{lang}-{pool8}-{seq4}
+            assert re.match(r'^ag-sbx-python-[a-f0-9]{8}-\d{4}$', name), f"Unexpected container name: {name}"
+
+    def test_container_name_sequence_increments(self):
+        """Test that sequential sandbox creations produce incrementing sequence numbers."""
+        import re
+        sequences = []
+        for _ in range(2):
+            with self.manager.acquire_sandbox(Language.PYTHON) as sandbox:
+                sandbox.container_ref.reload()
+                name = sandbox.container_ref.name
+                match = re.search(r'-(\d{4})$', name)
+                assert match, f"No sequence found in name: {name}"
+                sequences.append(int(match.group(1)))
+        # Sequences should be strictly increasing
+        assert sequences[1] > sequences[0], f"Sequences not incrementing: {sequences}"
+
     def test_shutdown_destroys_all_containers(self):
         """Test that shutdown destroys all containers."""
         # Acquire multiple sandboxes

--- a/tests/unit/test_sandbox_manager.py
+++ b/tests/unit/test_sandbox_manager.py
@@ -253,3 +253,46 @@ class TestSandboxContainer(unittest.TestCase):
 if __name__ == '__main__':
     unittest.main()
 
+
+class TestLanguagePoolNaming(unittest.TestCase):
+    """Test deterministic container naming in LanguagePool."""
+
+    def test_build_container_name_format(self):
+        """Test that _build_container_name produces ag-sbx-{lang}-{pool8}-{seq4}."""
+        import re
+        from sandbox_manager.language_pool import LanguagePool
+        from sandbox_manager.models.pool_config import SandboxPoolConfig
+
+        config = SandboxPoolConfig(
+            language=Language.PYTHON,
+            pool_size=1,
+            scale_limit=2,
+            idle_timeout=300,
+            running_timeout=60
+        )
+        pool = LanguagePool(Language.PYTHON, config, client=None)
+
+        name = pool._build_container_name()
+        assert re.match(r'^ag-sbx-python-[a-f0-9]{8}-0001$', name), f"Unexpected name: {name}"
+
+    def test_build_container_name_increments(self):
+        """Test that sequential calls produce incrementing sequence numbers."""
+        from sandbox_manager.language_pool import LanguagePool
+        from sandbox_manager.models.pool_config import SandboxPoolConfig
+
+        config = SandboxPoolConfig(
+            language=Language.JAVA,
+            pool_size=1,
+            scale_limit=2,
+            idle_timeout=300,
+            running_timeout=60
+        )
+        pool = LanguagePool(Language.JAVA, config, client=None)
+
+        name1 = pool._build_container_name()
+        name2 = pool._build_container_name()
+        assert name1.endswith("-0001")
+        assert name2.endswith("-0002")
+        # Same pool prefix
+        assert name1[:-5] == name2[:-5]
+


### PR DESCRIPTION
## Summary

Adopts a deterministic, human-readable naming convention for sandbox containers: `ag-sbx-{lang}-{pool8}-{seq4}`.

Examples: `ag-sbx-python-a1b2c3d4-0001`, `ag-sbx-node-a1b2c3d4-0002`

## Changes

- **`sandbox_manager/language_pool.py`** — Added per-pool sequence counter, `_build_container_name()` helper, and `name=` parameter in both gVisor and fallback container creation paths
- **`sandbox_manager/sandbox_container.py`** — Updated `__repr__` to include container name
- **`sandbox_manager/manager.py`** — Orphan cleanup logs now include container name alongside id
- **`tests/unit/test_sandbox_manager.py`** — Unit tests for name format and sequence incrementing
- **`tests/integration/test_sandbox_lifecycle.py`** — Integration tests for deterministic naming and sequence progression
- **`docs/architecture/sandbox_manager.md`** — Documented naming convention in Container Security section

Closes #265