### PR TITLE
enable feedback step

### DIFF
--- a/autograder/services/report/ai_reporter.py
+++ b/autograder/services/report/ai_reporter.py
@@ -1,7 +1,7 @@
 
 class AiReporter:
     """Reporter that uses AI to generate feedback."""
-    def generate_report(self, _focus, _result_tree, _preferences=None):
+    def generate_report(self, focus, result_tree, preferences=None):
         """Generates an AI-based report based on analysis results."""
         raise NotImplementedError("AI report generation logic not implemented yet.")
 

--- a/autograder/services/report/default_reporter.py
+++ b/autograder/services/report/default_reporter.py
@@ -33,7 +33,8 @@ class DefaultReporter:
 
         # 5. Online Resources
         if preferences and preferences.general.online_content:
-            lines.extend(self._add_online_resources(preferences.general.online_content, locale=locale))
+            failed_names = {t.name for t in result_tree.get_failed_tests()} if result_tree else set()
+            lines.extend(self._add_online_resources(preferences.general.online_content, failed_names, locale=locale))
 
         return "\n".join(lines)
 
@@ -92,10 +93,21 @@ class DefaultReporter:
             self._formatter.final_score(score)
         ]
 
-    def _add_online_resources(self, resources, locale: Optional[str] = None):
+    def _add_online_resources(self, resources, failed_test_names: set, locale=None):
+        """
+        Append learning resources to the report.
+
+        A resource is included if:
+        - it has no linked_tests (global resource, always shown), OR
+        - at least one of its linked_tests is in failed_test_names.
+        """
         resources_label = t("feedback.report.learning_resources_label", locale=locale) or "📚 Learning Resources"
         lines = ["", self._formatter.main_divisor(), f"## {resources_label}", ""]
-        for resource in resources:
+        visible = [
+            r for r in resources
+            if not r.linked_tests or (set(r.linked_tests) & failed_test_names)
+        ]
+        for resource in visible:
             lines.append(f"- 📘 [{resource.description}]({resource.url})")
-        return lines
+        return lines if len(lines) > 4 else []  # skip section if nothing to show
 

--- a/autograder/services/report/default_reporter.py
+++ b/autograder/services/report/default_reporter.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional
 from autograder.utils.formatters.result_tree import ResultTreeFormatter
 from autograder.translations import t
 

--- a/autograder/services/report/reporter_service.py
+++ b/autograder/services/report/reporter_service.py
@@ -2,7 +2,7 @@ from typing import Optional
 from autograder.services.report.default_reporter import DefaultReporter
 from autograder.services.report.ai_reporter import AiReporter
 from autograder.models.dataclass.feedback_preferences import (
-    FeedbackPreferences, GeneralPreferences, AiReporterPreferences, DefaultReporterPreferences
+    FeedbackPreferences, GeneralPreferences, AiReporterPreferences, DefaultReporterPreferences, LearningResource
 )
 
 
@@ -28,6 +28,13 @@ class ReporterService:
         general_cfg = feedback_config.get("general", {})
         ai_cfg = feedback_config.get("ai", {})
         default_cfg = feedback_config.get("default", {})
+
+        # Convert online_content dicts to LearningResource objects
+        if "online_content" in general_cfg:
+            general_cfg["online_content"] = [
+                LearningResource(**r) if isinstance(r, dict) else r 
+                for r in general_cfg["online_content"]
+            ]
 
         preferences = FeedbackPreferences(
             general=GeneralPreferences(**general_cfg),

--- a/docs/API.md
+++ b/docs/API.md
@@ -76,6 +76,21 @@ Content-Type: application/json
   "setup_config": {
     "required_files": ["main.py"],
     "setup_commands": []
+  },
+  "include_feedback": true,
+  "feedback_config": {
+    "general": {
+      "report_title": "Evaluation Report",
+      "show_score": true,
+      "show_passed_tests": false,
+      "add_report_summary": true,
+      "online_content": [
+        {
+          "url": "https://docs.python.org/3/tutorial/",
+          "description": "Python Tutorial"
+        }
+      ]
+    }
   }
 }
 ```
@@ -89,6 +104,8 @@ Content-Type: application/json
 | `criteria_config` | object | ✓ | Grading criteria tree configuration |
 | `languages` | list[string] | ✓ | Supported languages: `python`, `java`, `node`, `cpp` |
 | `setup_config` | object | ✗ | Setup configuration for preflight checks |
+| `include_feedback` | boolean | ✗ | Whether to generate a feedback report after grading (default: `true`) |
+| `feedback_config` | object | ✗ | Feedback preferences — see [FeedbackConfig Reference](#feedbackconfig-reference) |
 
 **Response (201 Created):**
 ```json
@@ -99,6 +116,8 @@ Content-Type: application/json
   "criteria_config": { ... },
   "languages": ["python", "java"],
   "setup_config": { ... },
+  "include_feedback": true,
+  "feedback_config": { ... },
   "version": 1,
   "created_at": "2026-02-16T10:00:00Z",
   "updated_at": "2026-02-16T10:00:00Z",
@@ -177,6 +196,8 @@ Content-Type: application/json
   "criteria_config": { ... },
   "languages": ["python", "node"],
   "setup_config": { ... },
+  "include_feedback": false,
+  "feedback_config": { ... },
   "is_active": false
 }
 ```
@@ -201,6 +222,8 @@ Use this endpoint when you only know the LMS-specific assignment identifier and 
   "criteria_config": { ... },
   "languages": ["python", "node"],
   "setup_config": { ... },
+  "include_feedback": true,
+  "feedback_config": { ... },
   "is_active": false
 }
 ```
@@ -210,6 +233,60 @@ Use this endpoint when you only know the LMS-specific assignment identifier and 
 **Error (404):** Configuration not found for the supplied `external_assignment_id`.
 
 ---
+
+## FeedbackConfig Reference
+
+The `feedback_config` object controls how the `DefaultReporter` generates the post-grading Markdown report. All fields are optional.
+
+```json
+{
+  "general": {
+    "report_title": "Evaluation Report",
+    "show_score": true,
+    "show_passed_tests": false,
+    "add_report_summary": true,
+    "online_content": [
+      {
+        "url": "https://docs.python.org/3/tutorial/",
+        "description": "Python Official Tutorial"
+      }
+    ]
+  },
+  "default": {
+    "category_headers": {
+      "base": "✅ Essential Requirements",
+      "penalty": "❌ Points to Improve",
+      "bonus": "⭐ Extra Points"
+    }
+  }
+}
+```
+
+### `general` fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `report_title` | string | `"Evaluation Report"` | Custom title at the top of the report |
+| `show_score` | boolean | `true` | Append the final score section at the bottom of the report |
+| `show_passed_tests` | boolean | `false` | Include tests that passed (score = 100) in the results |
+| `add_report_summary` | boolean | `true` | Add a summary section with template name and score breakdown |
+| `online_content` | list[object] | `[]` | Learning resources appended at the end of the report |
+
+### `online_content` object fields
+
+| Field | Type | Description |
+|-------|------|--------------|
+| `url` | string | Full URL of the resource |
+| `description` | string | Human-readable label for the link |
+| `linked_tests` | list[string] | Optional: List of test names. If provided, the resource is only shown if at least one of these tests fails. |
+
+Resources without `linked_tests` are always displayed at the end of the report. Resources with `linked_tests` act as "targeted hints" that only appear when relevant.
+
+### `default` fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `category_headers` | object | Override section headers per category (`base`, `penalty`, `bonus`) |
 
 ## Submissions
 

--- a/web/api/v1/grading_configs.py
+++ b/web/api/v1/grading_configs.py
@@ -53,6 +53,8 @@ async def create_grading_config(
         criteria_config=config.criteria_config,
         languages=config.languages,
         setup_config=config.setup_config,
+        feedback_config=config.feedback_config,
+        include_feedback=config.include_feedback,
     )
 
     logger.info(

--- a/web/api/v1/submissions.py
+++ b/web/api/v1/submissions.py
@@ -19,7 +19,7 @@ from web.schemas import (
     SubmissionResponse,
     SubmissionDetailResponse,
 )
-from web.service.grading_service import grade_submission
+from web.service.grading_service import grade_submission, GradingRequest
 
 
 logger = get_logger(__name__)
@@ -107,20 +107,19 @@ async def create_submission(
     # Schedule concurrent grading task using asyncio
     # This allows multiple submissions to be graded simultaneously,
     # fully utilizing the sandbox pool's capacity
-    task = asyncio.create_task(
-        grade_submission(
-            submission_id=db_submission.id,
-            grading_config_id=grading_config.id,
-            template_name=grading_config.template_name,
-            criteria_config=grading_config.criteria_config,
-            setup_config=grading_config.setup_config,
-            language=db_submission.language,
-            username=db_submission.username,
-            external_user_id=db_submission.external_user_id,
-            submission_files=db_submission.submission_files,
-            locale=submission.locale,
-        )
+    grading_request = GradingRequest(
+        submission_id=db_submission.id,
+        grading_config_id=grading_config.id,
+        template_name=grading_config.template_name,
+        criteria_config=grading_config.criteria_config,
+        setup_config=grading_config.setup_config,
+        language=db_submission.language,
+        username=db_submission.username,
+        external_user_id=db_submission.external_user_id,
+        submission_files=db_submission.submission_files,
+        locale=submission.locale,
     )
+    task = asyncio.create_task(grade_submission(grading_request))
 
     # Track task to prevent garbage collection
     grading_tasks = get_grading_tasks()

--- a/web/api/v1/submissions.py
+++ b/web/api/v1/submissions.py
@@ -113,6 +113,8 @@ async def create_submission(
         template_name=grading_config.template_name,
         criteria_config=grading_config.criteria_config,
         setup_config=grading_config.setup_config,
+        feedback_config=grading_config.feedback_config or {},
+        include_feedback=grading_config.include_feedback,
         language=db_submission.language,
         username=db_submission.username,
         external_user_id=db_submission.external_user_id,

--- a/web/database/models/grading_config.py
+++ b/web/database/models/grading_config.py
@@ -1,9 +1,9 @@
 """GradingConfiguration database model."""
 
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import Boolean, Integer, String, Text, DateTime, JSON
+from sqlalchemy import Boolean, Integer, String, DateTime, JSON
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 

--- a/web/database/models/grading_config.py
+++ b/web/database/models/grading_config.py
@@ -25,6 +25,8 @@ class GradingConfiguration(Base):
     criteria_config: Mapped[dict] = mapped_column(JSON, nullable=False)
     languages: Mapped[list] = mapped_column(JSON, nullable=False)  # List of supported languages
     setup_config: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+    feedback_config: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+    include_feedback: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     version: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)

--- a/web/database/models/grading_config.py
+++ b/web/database/models/grading_config.py
@@ -28,8 +28,8 @@ class GradingConfiguration(Base):
     feedback_config: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
     include_feedback: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     version: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)  # pylint: disable=not-callable
+    updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)  # pylint: disable=not-callable
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     
     # Relationships

--- a/web/migrations/versions/002_add_feedback_columns_to_grading_config.py
+++ b/web/migrations/versions/002_add_feedback_columns_to_grading_config.py
@@ -1,3 +1,4 @@
+# pylint: disable=invalid-name
 """add feedback columns to grading config
 
 Revision ID: 002

--- a/web/migrations/versions/002_add_feedback_columns_to_grading_config.py
+++ b/web/migrations/versions/002_add_feedback_columns_to_grading_config.py
@@ -7,16 +7,18 @@ Create Date: 2026-04-11
 """
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
+# pylint: disable=invalid-name
 revision = '002'
 down_revision = '001'
 branch_labels = None
 depends_on = None
+# pylint: enable=invalid-name
 
 
 def upgrade() -> None:
+    """Add feedback columns to grading_configurations table."""
     # Add feedback columns to grading_configurations table
     op.add_column('grading_configurations',
                   sa.Column('feedback_config', sa.JSON(), nullable=True))
@@ -25,6 +27,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    """Remove feedback columns from grading_configurations table."""
     # Remove feedback columns from grading_configurations table
     op.drop_column('grading_configurations', 'include_feedback')
     op.drop_column('grading_configurations', 'feedback_config')

--- a/web/migrations/versions/002_add_feedback_columns_to_grading_config.py
+++ b/web/migrations/versions/002_add_feedback_columns_to_grading_config.py
@@ -1,0 +1,30 @@
+"""add feedback columns to grading config
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-04-11
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '002'
+down_revision = '001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add feedback columns to grading_configurations table
+    op.add_column('grading_configurations',
+                  sa.Column('feedback_config', sa.JSON(), nullable=True))
+    op.add_column('grading_configurations',
+                  sa.Column('include_feedback', sa.Boolean(), server_default='true', nullable=False))
+
+
+def downgrade() -> None:
+    # Remove feedback columns from grading_configurations table
+    op.drop_column('grading_configurations', 'include_feedback')
+    op.drop_column('grading_configurations', 'feedback_config')

--- a/web/schemas/assignment.py
+++ b/web/schemas/assignment.py
@@ -18,7 +18,14 @@ class GradingConfigCreate(BaseModel):
         default=None,
         description="Setup configuration including required_files and setup_commands for preflight checks"
     )
-    # TODO: Include feedback options
+    feedback_config: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Feedback preferences for the DefaultReporter (show_score, show_passed_tests, report_title, etc.)"
+    )
+    include_feedback: bool = Field(
+        default=True,
+        description="Whether to generate a feedback report after grading"
+    )
 
     @field_validator('languages')
     @classmethod
@@ -64,6 +71,8 @@ class GradingConfigUpdate(BaseModel):
     criteria_config: Optional[Dict[str, Any]] = None
     languages: Optional[List[str]] = None
     setup_config: Optional[Dict[str, Any]] = None
+    feedback_config: Optional[Dict[str, Any]] = None
+    include_feedback: Optional[bool] = None
     is_active: Optional[bool] = None
 
     @field_validator('languages')
@@ -118,6 +127,8 @@ class GradingConfigResponse(BaseModel):
     criteria_config: Dict[str, Any]
     languages: List[str]
     setup_config: Optional[Dict[str, Any]]
+    feedback_config: Optional[Dict[str, Any]]
+    include_feedback: bool
     version: int
     created_at: datetime
     updated_at: datetime

--- a/web/service/grading_service.py
+++ b/web/service/grading_service.py
@@ -28,6 +28,8 @@ class GradingRequest:
     template_name: str
     criteria_config: dict
     setup_config: dict
+    feedback_config: dict
+    include_feedback: bool
     language: str
     username: str
     external_user_id: str
@@ -88,9 +90,9 @@ async def _run_pipeline(request: GradingRequest):
     """Build the autograder pipeline and run it in a thread."""
     pipeline = build_pipeline(
         template_name=request.template_name,
-        include_feedback=True,
+        include_feedback=request.include_feedback,
         grading_criteria=request.criteria_config,
-        feedback_config={},
+        feedback_config=request.feedback_config or {},
         setup_config=request.setup_config if request.setup_config else {},
         custom_template=None,
     )

--- a/web/service/grading_service.py
+++ b/web/service/grading_service.py
@@ -51,11 +51,12 @@ async def grade_submission(
             # Build autograder pipeline
             pipeline = build_pipeline(
                 template_name=template_name,
-                include_feedback=False,  # Keep False for now
+                include_feedback=True,
                 grading_criteria=criteria_config,
-                feedback_config=None,
+                feedback_config={},
                 setup_config=setup_config if setup_config else {},
                 custom_template=None,  # Keep None to use default template behavior
+                locale=locale,
             )
 
             files_to_grade = {

--- a/web/service/grading_service.py
+++ b/web/service/grading_service.py
@@ -2,10 +2,12 @@
 
 import asyncio
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from autograder.autograder import build_pipeline
 from autograder.models.dataclass.submission import Submission as AutograderSubmission, SubmissionFile
+from autograder.utils.feedback_generator import generate_preflight_feedback
 from sandbox_manager.models.sandbox_models import Language
 from web.config.logging import get_logger
 from web.database import get_session
@@ -18,24 +20,31 @@ from autograder.serializers.pipeline_execution_serializer import PipelineExecuti
 logger = get_logger(__name__)
 
 
-async def grade_submission(
-    submission_id: int,
-    grading_config_id: int,
-    template_name: str,
-    criteria_config: dict,
-    setup_config: dict,
-    language: str,
-    username: str,
-    external_user_id: str,
-    submission_files: dict,
-    locale: str = "en",
-):
+@dataclass
+class GradingRequest:
+    """Encapsulates all parameters needed to grade a submission."""
+    submission_id: int
+    grading_config_id: int
+    template_name: str
+    criteria_config: dict
+    setup_config: dict
+    language: str
+    username: str
+    external_user_id: str
+    submission_files: dict
+    locale: str = "en"
+
+
+async def grade_submission(request: GradingRequest) -> None:
     """
     Background task to grade a submission.
 
     This function runs the autograder pipeline on the submission and stores results.
     """
-    logger.info(f"Starting grading for submission {submission_id} (user: {username})")
+    logger.info(
+        "Starting grading for submission %d (user: %s)",
+        request.submission_id, request.username
+    )
     start_time = time.time()
 
     async with get_session() as session:
@@ -43,144 +52,131 @@ async def grade_submission(
         result_repo = ResultRepository(session)
 
         try:
-            # Update status to processing
-            await submission_repo.update_status(submission_id, SubmissionStatus.PROCESSING)
+            await submission_repo.update_status(request.submission_id, SubmissionStatus.PROCESSING)
             await session.commit()
-            logger.info(f"Submission {submission_id} status updated to PROCESSING")
+            logger.info("Submission %d status updated to PROCESSING", request.submission_id)
 
-            # Build autograder pipeline
-            pipeline = build_pipeline(
-                template_name=template_name,
-                include_feedback=True,
-                grading_criteria=criteria_config,
-                feedback_config={},
-                setup_config=setup_config if setup_config else {},
-                custom_template=None,  # Keep None to use default template behavior
-                locale=locale,
-            )
-
-            files_to_grade = {
-                name: SubmissionFile(filename=f["filename"], content=f["content"])
-                for name, f in submission_files.items()
-            }
-
-            # Convert to Autograder Submission object
-            autograder_submission = AutograderSubmission(
-                username=username,
-                user_id=external_user_id,
-                assignment_id=grading_config_id,
-                submission_files=files_to_grade,
-                language=Language[language.upper()] if language else None,
-                locale=locale,
-            )
-
-            # Run pipeline in a thread to avoid blocking the event loop
-            # This allows multiple submissions to be graded concurrently,
-            # each acquiring their own sandbox container from the pool
-            pipeline_execution = await asyncio.to_thread(pipeline.run, autograder_submission)
-
-            # Calculate execution time
+            pipeline_execution = await _run_pipeline(request)
             execution_time_ms = int((time.time() - start_time) * 1000)
 
-            # Extract results
             if pipeline_execution.result:
-                final_score = pipeline_execution.result.final_score
-                feedback = pipeline_execution.result.feedback
-                result_tree = pipeline_execution.result.result_tree
-                focus = pipeline_execution.result.focus
-
-                # Convert result_tree to dict for JSON storage
-                result_tree_dict = None
-                if result_tree:
-                    result_tree_dict = {
-                        "final_score": pipeline_execution.result.final_score,
-                        "children": _node_to_dict(result_tree.root)
-                    }
-
-                # Convert focus to dict for JSON storage
-                focus_dict = None
-                if focus:
-                    focus_dict = focus.to_dict()
-
-                pipeline_summary = PipelineExecutionSerializer.serialize(pipeline_execution)
-
-                # Store result
-                await result_repo.create(
-                    submission_id=submission_id,
-                    final_score=final_score,
-                    result_tree=result_tree_dict,
-                    feedback=feedback,
-                    focus=focus_dict,
-                    pipeline_execution=pipeline_summary,
-                    execution_time_ms=execution_time_ms,
-                    pipeline_status=PipelineStatus.SUCCESS,
-                )
-
-                # Update submission status
-                await submission_repo.update(
-                    submission_id,
-                    status=SubmissionStatus.COMPLETED,
-                    graded_at=datetime.now(timezone.utc).replace(tzinfo=None)
-                )
-
-                logger.info(
-                    f"Submission {submission_id} graded successfully. "
-                    f"Score: {final_score}, Time: {execution_time_ms}ms"
-                )
+                await _persist_success(result_repo, submission_repo, request, pipeline_execution, execution_time_ms)
             else:
-                # Pipeline failed
-                error_msg = "Pipeline failed to produce results"
-                if pipeline_execution.step_results:
-                    last_step = pipeline_execution.get_previous_step()
-                    if last_step and last_step.error:
-                        error_msg = last_step.error
-
-                logger.warning(f"Submission {submission_id} pipeline failed: {error_msg}")
-
-                # Generate pipeline execution summary
-                pipeline_summary = PipelineExecutionSerializer.serialize(pipeline_execution)
-
-                # Generate enhanced feedback for preflight failures
-                from autograder.utils.feedback_generator import generate_preflight_feedback
-                feedback = None
-                failed_step_name = pipeline_summary.get("failed_at_step")
-                if failed_step_name == "PreFlightStep":
-                    feedback = generate_preflight_feedback(pipeline_summary, locale=locale)
-
-                await result_repo.create(
-                    submission_id=submission_id,
-                    final_score=0.0,
-                    feedback=feedback,
-                    pipeline_execution=pipeline_summary,
-                    execution_time_ms=execution_time_ms,
-                    pipeline_status=PipelineStatus.FAILED,
-                    error_message=error_msg,
-                    failed_at_step=failed_step_name
-                )
-
-                await submission_repo.update_status(submission_id, SubmissionStatus.FAILED)
+                await _persist_failure(result_repo, submission_repo, request, pipeline_execution, execution_time_ms)
 
             await session.commit()
 
-        except Exception as e:
-            # Handle unexpected errors
+        except Exception as exc:  # pylint: disable=broad-exception-caught
             execution_time_ms = int((time.time() - start_time) * 1000)
-
             await result_repo.create(
-                submission_id=submission_id,
+                submission_id=request.submission_id,
                 final_score=0.0,
                 execution_time_ms=execution_time_ms,
                 pipeline_status=PipelineStatus.INTERRUPTED,
-                error_message=str(e),
+                error_message=str(exc),
             )
-
-            await submission_repo.update_status(submission_id, SubmissionStatus.FAILED)
+            await submission_repo.update_status(request.submission_id, SubmissionStatus.FAILED)
             await session.commit()
-
             logger.error(
-                f"Error grading submission {submission_id}: {str(e)}",
+                "Error grading submission %d: %s",
+                request.submission_id, str(exc),
                 exc_info=True
             )
+
+
+async def _run_pipeline(request: GradingRequest):
+    """Build the autograder pipeline and run it in a thread."""
+    pipeline = build_pipeline(
+        template_name=request.template_name,
+        include_feedback=True,
+        grading_criteria=request.criteria_config,
+        feedback_config={},
+        setup_config=request.setup_config if request.setup_config else {},
+        custom_template=None,
+    )
+
+    files_to_grade = {
+        name: SubmissionFile(filename=f["filename"], content=f["content"])
+        for name, f in request.submission_files.items()
+    }
+
+    autograder_submission = AutograderSubmission(
+        username=request.username,
+        user_id=request.external_user_id,
+        assignment_id=request.grading_config_id,
+        submission_files=files_to_grade,
+        language=Language[request.language.upper()] if request.language else None,
+        locale=request.locale,
+    )
+
+    return await asyncio.to_thread(pipeline.run, autograder_submission)
+
+
+async def _persist_success(result_repo, submission_repo, request: GradingRequest, pipeline_execution, execution_time_ms: int) -> None:
+    """Store successful grading results and update submission status."""
+    result = pipeline_execution.result
+    result_tree_dict = None
+    if result.result_tree:
+        result_tree_dict = {
+            "final_score": result.final_score,
+            "children": _node_to_dict(result.result_tree.root),
+        }
+
+    focus_dict = result.focus.to_dict() if result.focus else None
+    pipeline_summary = PipelineExecutionSerializer.serialize(pipeline_execution)
+
+    await result_repo.create(
+        submission_id=request.submission_id,
+        final_score=result.final_score,
+        result_tree=result_tree_dict,
+        feedback=result.feedback,
+        focus=focus_dict,
+        pipeline_execution=pipeline_summary,
+        execution_time_ms=execution_time_ms,
+        pipeline_status=PipelineStatus.SUCCESS,
+    )
+
+    await submission_repo.update(
+        request.submission_id,
+        status=SubmissionStatus.COMPLETED,
+        graded_at=datetime.now(timezone.utc).replace(tzinfo=None),
+    )
+
+    logger.info(
+        "Submission %d graded successfully. Score: %s, Time: %dms",
+        request.submission_id, result.final_score, execution_time_ms
+    )
+
+
+async def _persist_failure(result_repo, submission_repo, request: GradingRequest, pipeline_execution, execution_time_ms: int) -> None:
+    """Store failed grading results and update submission status."""
+    error_msg = "Pipeline failed to produce results"
+    if pipeline_execution.step_results:
+        last_step = pipeline_execution.get_previous_step()
+        if last_step and last_step.error:
+            error_msg = last_step.error
+
+    logger.warning("Submission %d pipeline failed: %s", request.submission_id, error_msg)
+
+    pipeline_summary = PipelineExecutionSerializer.serialize(pipeline_execution)
+
+    feedback = None
+    failed_step_name = pipeline_summary.get("failed_at_step")
+    if failed_step_name == "PreFlightStep":
+        feedback = generate_preflight_feedback(pipeline_summary, locale=request.locale)
+
+    await result_repo.create(
+        submission_id=request.submission_id,
+        final_score=0.0,
+        feedback=feedback,
+        pipeline_execution=pipeline_summary,
+        execution_time_ms=execution_time_ms,
+        pipeline_status=PipelineStatus.FAILED,
+        error_message=error_msg,
+        failed_at_step=failed_step_name,
+    )
+
+    await submission_repo.update_status(request.submission_id, SubmissionStatus.FAILED)
 
 
 def _node_to_dict(node) -> dict:
@@ -191,13 +187,10 @@ def _node_to_dict(node) -> dict:
     if node is None:
         return {}
 
-    # If the node has its own to_dict method (like ResultTree, RootResultNode, etc.)
-    if hasattr(node, 'to_dict') and callable(getattr(node, 'to_dict')):
+    if hasattr(node, "to_dict") and callable(getattr(node, "to_dict")):
         return node.to_dict()
 
-    # Fallback for unexpected types or raw lists of children
     if isinstance(node, list):
         return [_node_to_dict(child) for child in node]
 
     return {}
-


### PR DESCRIPTION
This pull request refactors the grading workflow to use a new `GradingRequest` dataclass for improved clarity and maintainability. It also restructures the grading logic into smaller helper functions for better error handling and separation of concerns.

**API and Data Structure Improvements:**

* Introduced a `GradingRequest` dataclass to encapsulate all parameters needed for grading a submission, replacing the previous use of multiple function arguments. (`web/service/grading_service.py`)
* Updated the API endpoint (`create_submission`) to create and pass a `GradingRequest` object to the grading task, instead of passing individual parameters. (`web/api/v1/submissions.py`) [[1]](diffhunk://#diff-ad4e6ab4a738935e43e718ce42367c77e72d9bbc9adf50f07ef204024995c98dL22-R22) [[2]](diffhunk://#diff-ad4e6ab4a738935e43e718ce42367c77e72d9bbc9adf50f07ef204024995c98dL110-R110) [[3]](diffhunk://#diff-ad4e6ab4a738935e43e718ce42367c77e72d9bbc9adf50f07ef204024995c98dL123-R122)

**Grading Logic Refactoring:**

* Refactored the main grading function (`grade_submission`) to accept a `GradingRequest` and split the logic into helper functions: `_run_pipeline`, `_persist_success`, and `_persist_failure`, improving readability and error handling. (`web/service/grading_service.py`)
* Enhanced error handling during grading: now logs errors with more detail and handles both pipeline and unexpected failures more robustly. (`web/service/grading_service.py`)

**Feedback and Result Handling:**

* Improved feedback generation for preflight failures and ensured result trees and focus are serialized properly for storage. (`web/service/grading_service.py`)

**Minor Cleanups:**

* Cleaned up and clarified the `_node_to_dict` utility function for serializing result trees. (`web/service/grading_service.py`)