### PR TITLE
docs: add MkDocs portal and core concept guides

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -1,0 +1,66 @@
+name: Build and Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+      - '.github/workflows/docs-pages.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+      - '.github/workflows/docs-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install docs dependencies
+        run: pip install -r requirements-docs.txt
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - name: Setup Pages
+        if: github.event_name != 'pull_request'
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
       - 'web/schemas/**'
       - 'web/api/**'
       - 'scripts/validate_docs.py'
@@ -16,5 +18,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Install docs dependencies
+        run: pip install -r requirements-docs.txt
       - name: Validate documentation
         run: python scripts/validate_docs.py
+      - name: Build docs site
+        run: mkdocs build --strict

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 # Makefile for Autograder Development
 # Simplifies common development tasks
 
-.PHONY: help install install-dev test test-cov lint format type-check security clean build docs run-api run-api-tests examples-demo start-autograder docker-build sandbox-build sandbox-build-all sandbox-clean db-migrate db-upgrade db-downgrade db-current db-history db-init db-reset
+.PHONY: help install install-dev test test-cov lint format type-check security clean build docs docs-build docs-serve run-api run-api-tests examples-demo start-autograder docker-build sandbox-build sandbox-build-all sandbox-clean db-migrate db-upgrade db-downgrade db-current db-history db-init db-reset
 
 # Default target
 help:
 	@echo "Available commands:"
 	@echo "  make install             - Install production dependencies"
+	@echo "  make docs-build          - Build docs site with MkDocs (strict mode)"
+	@echo "  make docs-serve          - Serve docs site locally with live reload"
 	@echo "  make examples-demo       - Run interactive demo webpage"
 	@echo "  make start-autograder    - Start the Autograder API server"
 	@echo ""
@@ -31,6 +33,12 @@ help:
 # Installation
 install:
 	pip install -r requirements.txt
+
+docs-build:
+	mkdocs build --strict
+
+docs-serve:
+	mkdocs serve
 
 # Database Migrations
 db-upgrade:
@@ -126,6 +134,5 @@ sandbox-test:
 sandbox-list:
 	@echo "Sandbox images:"
 	@docker images | grep sandbox- || echo "No sandbox images found"
-
 
 

--- a/README.md
+++ b/README.md
@@ -312,6 +312,33 @@ Includes endpoints for:
 
 ---
 
+## Documentation Website (MkDocs)
+
+The documentation now ships as an MkDocs site with focused learning paths for:
+
+- Pipeline architecture
+- Criteria tree design
+- Sandbox management
+- Template system
+- Feedback generation and educational standards
+
+Run locally:
+
+```bash
+pip install -r requirements-docs.txt
+mkdocs serve
+```
+
+Build in strict mode:
+
+```bash
+mkdocs build --strict
+```
+
+Core docs entry point: **[docs/index.md](docs/index.md)**
+
+---
+
 ## GitHub Action
 
 Seamlessly integrate with GitHub Classroom.
@@ -439,4 +466,3 @@ For questions, suggestions, or support:
 Made by educators, for educators
 
 </div>
-

--- a/docs/core/criteria-tree.md
+++ b/docs/core/criteria-tree.md
@@ -58,8 +58,8 @@ Use subject names that represent real learning objectives ("Input validation", "
         "subject_name": "Correctness",
         "weight": 70,
         "tests": [
-          {"name": "expect_output", "weight": 70, "parameters": {"expected_output": "42"}},
-          {"name": "dont_fail", "weight": 30, "parameters": {"inputs": ["10"]}}
+          {"name": "expect_output", "weight": 70, "parameters": {"expected_output": "42", "inputs": ["10"]}},
+          {"name": "dont_fail", "weight": 30, "parameters": {"user_input": "10"}}
         ]
       },
       {

--- a/docs/core/criteria-tree.md
+++ b/docs/core/criteria-tree.md
@@ -1,0 +1,87 @@
+# Criteria Tree
+
+## What it is
+
+The **Criteria Tree** is the rubric model used by the grader. It defines *what is evaluated* and *how much each part contributes*.
+
+Top-level categories:
+
+- `base` (required)
+- `bonus` (optional)
+- `penalty` (optional)
+
+Each category can contain nested subjects and tests.
+
+## Why it matters
+
+The criteria tree is where educational policy becomes executable logic:
+
+- Transparency: students see what was expected.
+- Fairness: every submission is graded with the same rubric structure.
+- Maintainability: rubric changes are config updates, not code rewrites.
+
+## How scoring works
+
+1. Tests produce scores in the 0-100 range.
+2. Subjects aggregate child tests/subjects by weight.
+3. Categories aggregate their children by weight.
+4. Final score is computed in `ResultTree` root:
+
+```text
+final = base + bonus_contribution - penalty_contribution
+```
+
+The root score is capped to `[0, 100]`.
+
+## Key concepts you should model explicitly
+
+### 1. Weight hierarchy
+
+Weights are local to sibling groups. A test's final impact depends on all ancestor weights.
+
+### 2. `subjects_weight`
+
+When a node has both direct tests and child subjects, `subjects_weight` splits influence between the two groups.
+
+### 3. Educational intent
+
+Use subject names that represent real learning objectives ("Input validation", "API contracts", "Accessibility"), not implementation jargon.
+
+## Concrete configuration example
+
+```json
+{
+  "base": {
+    "weight": 100,
+    "subjects": [
+      {
+        "subject_name": "Correctness",
+        "weight": 70,
+        "tests": [
+          {"name": "expect_output", "weight": 70, "parameters": {"expected_output": "42"}},
+          {"name": "dont_fail", "weight": 30, "parameters": {"inputs": ["10"]}}
+        ]
+      },
+      {
+        "subject_name": "Code Quality",
+        "weight": 30,
+        "tests": [
+          {"name": "forbidden_import", "weight": 100, "parameters": {"forbidden_imports": ["os.system"]}}
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Common mistakes
+
+- Setting arbitrary weights without tying them to learning objectives
+- Overusing deeply nested subjects that are hard for students to interpret
+- Mixing "must-have" and "nice-to-have" requirements in the same weighted group
+
+## Continue reading
+
+- [Educational Criteria Design](../guides/criteria-tree-educational-standards.md)
+- [Grading Engine Deep Dive](../features/grading_engine.md)
+- [Configuration Examples](../guides/criteria_configuration_examples.md)

--- a/docs/core/feedback-generation.md
+++ b/docs/core/feedback-generation.md
@@ -1,0 +1,57 @@
+# Feedback Generation
+
+## What it is
+
+Feedback generation transforms grading data into student-facing guidance.
+
+In this architecture, feedback is generated from:
+
+- `ResultTree` (full scoring structure)
+- `Focus` (tests ranked by score impact)
+- `FeedbackPreferences` (report configuration)
+
+## Why it matters
+
+A grading system is educational only when results are understandable and actionable. Feedback is the layer that turns "a score" into "a next learning step."
+
+## Pipeline position
+
+```text
+... -> GRADE -> FOCUS -> FEEDBACK -> ...
+```
+
+Feedback runs only when `include_feedback=True`.
+
+## How it works
+
+1. `FeedbackStep` reads focus and result tree from `PipelineExecution`.
+2. `ReporterService` selects reporter mode:
+   - `default` -> `DefaultReporter`
+   - `ai` -> `AiReporter` (not implemented yet)
+3. Preferences are parsed from `feedback_config`.
+4. Reporter returns Markdown content.
+
+## Educational quality patterns
+
+High-quality reports should:
+
+- prioritize high-impact failures first
+- keep feedback objective and rubric-aligned
+- include targeted learning resources where possible
+- separate required improvements from bonus opportunities
+
+## Linking resources to criteria
+
+`online_content` resources can be linked to specific test names. This lets the report include remediation links only when relevant tests fail.
+
+## Common mistakes
+
+- Long generic feedback that ignores focus ordering
+- Hiding score breakdown while expecting students to self-diagnose
+- Enabling AI mode in production before AI reporter implementation is complete
+
+## Continue reading
+
+- [Pipeline Step: Feedback](../pipeline/07-feedback.md)
+- [Focus Feature](../features/focus_feature.md)
+- [Educational Criteria Design](../guides/criteria-tree-educational-standards.md)

--- a/docs/core/pipeline-architecture.md
+++ b/docs/core/pipeline-architecture.md
@@ -1,0 +1,60 @@
+# Pipeline Architecture
+
+## What it is
+
+The Autograder pipeline is the execution backbone that turns one submission into a complete grading result.
+
+Every run follows a fixed order built by `build_pipeline()`:
+
+```text
+LOAD_TEMPLATE -> BUILD_TREE -> SANDBOX -> PRE_FLIGHT -> AI_BATCH -> GRADE -> FOCUS -> FEEDBACK? -> EXPORT?
+```
+
+`FEEDBACK` and `EXPORT` are optional, based on configuration.
+
+## Why it matters
+
+- It keeps grading deterministic and debuggable.
+- It separates concerns: each step has one responsibility.
+- It makes extension safer: new behaviors can be added as steps, not scattered conditionals.
+
+## How it works
+
+1. `AutograderPipeline.run(submission)` creates a `PipelineExecution`.
+2. Each step receives the same `PipelineExecution` and appends one `StepResult`.
+3. If a step fails, execution stops early.
+4. `finish_execution()` assembles `GradingResult` from grade/focus/feedback artifacts.
+5. Sandbox cleanup runs at the end.
+
+## Core data contract
+
+`PipelineExecution` is the shared contract between steps:
+
+- Submission data (`submission`)
+- Ordered step outputs (`step_results`)
+- Runtime status (`status`)
+- Final result (`result`)
+
+Typed accessors such as `get_loaded_template()`, `get_built_criteria_tree()`, `get_result_tree()`, and `get_focus()` prevent ad-hoc data access in step implementations.
+
+## Example mental model
+
+Think of the pipeline as a production line:
+
+- **Load Template** chooses the toolset
+- **Build Tree** builds the rubric structure
+- **Sandbox + Pre-Flight** prepares a safe execution environment
+- **Grade** produces raw scoring results
+- **Focus + Feedback** convert scoring into learning guidance
+
+## Common mistakes
+
+- Treating steps as independent services without respecting step order dependencies
+- Generating feedback without focus data
+- Documenting only successful flow and skipping fail-fast behavior
+
+## Continue reading
+
+- [Pipeline Deep Dive](../pipeline/README.md)
+- [Pipeline Execution Tracking](../architecture/pipeline_execution_tracking.md)
+- [Feedback Generation](feedback-generation.md)

--- a/docs/core/sandbox-management.md
+++ b/docs/core/sandbox-management.md
@@ -1,0 +1,55 @@
+# Sandbox Management
+
+## What it is
+
+Sandbox management is the isolation layer used when templates require code execution.
+
+It is implemented by `SandboxManager`, which coordinates per-language `LanguagePool` instances and `SandboxContainer` objects.
+
+## Why it matters
+
+- Safety: untrusted student code runs in constrained containers.
+- Performance: warm pools remove most container cold-start delay.
+- Reliability: lifecycle controls avoid resource leaks and stale execution environments.
+
+## How it works
+
+1. App startup initializes one pool per configured language.
+2. Each pool pre-warms `pool_size` containers.
+3. Grading requests acquire an idle sandbox or scale up until `scale_limit`.
+4. Containers are released back to the pool after execution.
+5. Monitor thread enforces timeout-based cleanup and replenishment.
+
+## Resource and isolation controls
+
+Current container setup includes strict controls such as:
+
+- memory limits
+- CPU limits
+- process count limits
+- disabled network mode
+- dropped Linux capabilities
+
+Runtime prefers gVisor (`runsc`) when available and falls back to default runtime when unavailable.
+
+## Operational tuning
+
+| Goal | Main knobs |
+|------|------------|
+| Faster first response | Increase `pool_size` |
+| Higher concurrency | Increase `scale_limit` |
+| Lower idle resource usage | Lower `idle_timeout` |
+| Faster stuck-process recovery | Lower `running_timeout` |
+
+These values are defined in `sandbox_config.yml`.
+
+## Common mistakes
+
+- Treating a timeout sandbox as reusable after fatal execution behavior
+- Aggressive pool downsizing that causes repeated cold starts
+- Raising scale limits without host capacity checks
+
+## Continue reading
+
+- [Sandbox Manager Internals](../architecture/sandbox_manager.md)
+- [Pipeline Step: Sandbox](../pipeline/03-sandbox.md)

--- a/docs/core/template-system.md
+++ b/docs/core/template-system.md
@@ -1,0 +1,61 @@
+# Template System
+
+## What it is
+
+Templates define the available test functions for a grading context (input/output, API, web development, etc.).
+
+The `TemplateLibraryService` loads and caches template instances from a registry.
+
+## Why it matters
+
+- Keeps grading logic reusable across assignments
+- Prevents assignment configs from referencing unknown tests
+- Decouples rubric configuration from concrete test implementation
+
+## Built-in template identifiers
+
+Current registry keys:
+
+- `input_output`
+- `api`
+- `webdev`
+
+Each key resolves to a template class with:
+
+- `template_name`
+- `template_description`
+- `requires_sandbox`
+- `tests` map of available `TestFunction` objects
+
+## How it integrates with the pipeline
+
+1. **Load Template** resolves the chosen template.
+2. **Build Tree** validates and binds test names from criteria config to concrete test functions.
+3. **Grade** executes bound tests with parameters from the criteria tree.
+
+This means template validation is front-loaded, not deferred to scoring time.
+
+## Extending templates
+
+To add a new template:
+
+1. Implement template and test functions under `autograder/template_library/`.
+2. Register it in `TemplateLibraryService._TEMPLATE_REGISTRY`.
+3. Add docs for available tests and parameters.
+
+## Current limitation
+
+`load_custom_template()` exists but currently raises `NotImplementedError`. Built-in templates are the supported path today.
+
+## Common mistakes
+
+- Reusing test names with different semantics across templates
+- Skipping documentation for template parameters
+- Assuming sandbox availability in templates that declare `requires_sandbox = False`
+
+## Continue reading
+
+- [Pipeline Step: Load Template](../pipeline/01-load-template.md)
+- [Input/Output Template](../template-library/input_output.md)
+- [API Testing Template](../template-library/api_testing.md)
+- [Web Development Template](../template-library/web_dev.md)

--- a/docs/getting-started/mkdocs-local-development.md
+++ b/docs/getting-started/mkdocs-local-development.md
@@ -1,0 +1,40 @@
+# Local Docs Development (MkDocs)
+
+This project uses **MkDocs Material** to publish the documentation website.
+
+## Run locally
+
+```bash
+pip install -r requirements-docs.txt
+mkdocs serve
+```
+
+Open `http://127.0.0.1:8000` to preview changes with live reload.
+
+## Build locally
+
+```bash
+mkdocs build --strict
+```
+
+`--strict` turns warnings into errors, which helps catch broken navigation or links before opening a PR.
+
+## Where to edit
+
+- Main landing page: `docs/index.md`
+- Core concept pages: `docs/core/`
+- Pipeline deep dives: `docs/pipeline/`
+- Architecture references: `docs/architecture/`
+- Roadmaps: `docs/roadmaps/`
+
+## Documentation standards
+
+Every new technical page should follow this teaching pattern:
+
+1. **What it is**
+2. **Why it matters**
+3. **How it works**
+4. **Concrete example**
+5. **Common mistakes**
+
+For rubric quality guidance, use [Educational Criteria Design](../guides/criteria-tree-educational-standards.md).

--- a/docs/guides/criteria-tree-educational-standards.md
+++ b/docs/guides/criteria-tree-educational-standards.md
@@ -1,0 +1,69 @@
+# Educational Criteria Design with the Criteria Tree
+
+This guide explains how to design rubrics that are technically precise and pedagogically useful.
+
+## 1. Start from learning outcomes, not test tools
+
+Write outcomes first, then map them to subjects/tests.
+
+Good outcome labels:
+
+- "Correctly handles malformed input"
+- "Implements REST semantics for status codes"
+- "Uses semantic HTML structure"
+
+Weak outcome labels:
+
+- "Passes regex test 3"
+- "No warning in command X"
+
+## 2. Use category intent clearly
+
+- **Base**: required competencies
+- **Bonus**: enrichment, not compensation for missing fundamentals
+- **Penalty**: explicit deductions (late policy, disallowed behavior)
+
+Avoid putting mandatory requirements in `bonus`.
+
+## 3. Keep subject granularity meaningful
+
+Each subject should represent a coherent skill block. If a subject has one tiny test only, consider merging it. If a subject has too many unrelated tests, split it.
+
+## 4. Weight by instructional importance
+
+A suggested calibration process:
+
+1. Rank outcomes by instructional importance.
+2. Convert ranking into percentages.
+3. Verify total category and sibling weights make sense to humans.
+4. Validate the rubric with 3-5 representative submissions.
+
+## 5. Build explainable feedback paths
+
+For each high-priority test, define:
+
+- clear failure wording
+- likely root cause hints
+- one remediation resource (URL, section, or exercise)
+
+This keeps feedback actionable without becoming overwhelming.
+
+## 6. Keep rubrics stable across attempts
+
+Frequent rubric changes reduce fairness and comparability between attempts. Version rubric changes intentionally and communicate major shifts.
+
+## Quality checklist
+
+Use this before publishing an assignment rubric:
+
+- Does every weighted node map to a real learning outcome?
+- Can a student explain score loss from the generated report?
+- Do penalties reflect explicit policy and not hidden expectations?
+- Are resources linked to likely failure points?
+- Is the rubric understandable by another instructor without extra context?
+
+## Related docs
+
+- [Criteria Tree](../core/criteria-tree.md)
+- [Feedback Generation](../core/feedback-generation.md)
+- [Criteria Configuration Examples](criteria_configuration_examples.md)

--- a/docs/guides/github_module.md
+++ b/docs/guides/github_module.md
@@ -14,19 +14,19 @@ In short, the adopted solution consists of running a Docker container with the d
 
 ## Flow
 
-1. [Action.yml](../../action.yml)
+1. [Action.yml](https://github.com/webtech-network/autograder/blob/main/action.yml)
    Defines the inputs received by the action, describes the output as a JSON evaluation, and runs the container with the received data as environment variables.
 
-2. [Dockerfile](../../Dockerfile.actions)
-   Builds the container that installs the Autograder repository and sets [Entrypoint.sh](../../github_action/entrypoint.sh) as the script to be executed when the container starts.
+2. [Dockerfile](https://github.com/webtech-network/autograder/blob/main/Dockerfile.actions)
+   Builds the container that installs the Autograder repository and sets [Entrypoint.sh](https://github.com/webtech-network/autograder/blob/main/github_action/entrypoint.sh) as the script to be executed when the container starts.
 
-3. [Entrypoint.sh](../../github_action/entrypoint.sh)
-   Validates that the required environment variables are present and executes [main.py](../../github_action/main.py) with the received data passed as CLI arguments.
+3. [Entrypoint.sh](https://github.com/webtech-network/autograder/blob/main/github_action/entrypoint.sh)
+   Validates that the required environment variables are present and executes [main.py](https://github.com/webtech-network/autograder/blob/main/github_action/main.py) with the received data passed as CLI arguments.
 
-4. [main.py](../../github_action/main.py)
-   Validates arguments, captures errors, and manipulates variables to run [github_action_service.py](../../github_action/github_action_service.py) correctly in order to obtain and send the results.
+4. [main.py](https://github.com/webtech-network/autograder/blob/main/github_action/main.py)
+   Validates arguments, captures errors, and manipulates variables to run [github_action_service.py](https://github.com/webtech-network/autograder/blob/main/github_action/github_action_service.py) correctly in order to obtain and send the results.
 
-5. [github_action_service.py](../../github_action/github_action_service.py)
+5. [github_action_service.py](https://github.com/webtech-network/autograder/blob/main/github_action/github_action_service.py)
    Implements the underlying details based on Autograder's methods and the GitHub library to execute the logical procedures.
 
 ## Local testing

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,69 +1,43 @@
-# 📚 Autograder Documentation
+# Autograder Documentation
 
-Welcome to the Autograder documentation. This index organizes all available documentation by topic.
+This documentation is organized to be both practical for first-time users and deep enough for maintainers working on the grading engine internals.
 
----
+## Start Here
 
-## Getting Started
+1. [Pipeline Architecture](core/pipeline-architecture.md)
+2. [Criteria Tree](core/criteria-tree.md)
+3. [Sandbox Management](core/sandbox-management.md)
+4. [Template System](core/template-system.md)
+5. [Feedback Generation](core/feedback-generation.md)
 
-| Document | Description |
-|----------|-------------|
-| [README](../README.md) | Project overview, features, and quick start |
-| [Development Guide](guides/development.md) | Setup, project structure, and contributing |
-| [Configuration Examples](guides/criteria_configuration_examples.md) | Real-world grading configuration examples |
+## Learning Paths
 
-## API Reference
+### Educator or instructional designer
 
-| Document | Description |
-|----------|-------------|
-| [API Documentation](API.md) | Complete REST API reference — all endpoints, schemas, and examples |
-| [Web Module Architecture](architecture/web_module.md) | Web layer architecture, deployment, database configuration, and troubleshooting |
+- [Educational Criteria Design Guide](guides/criteria-tree-educational-standards.md)
+- [Criteria Configuration Examples](guides/criteria_configuration_examples.md)
+- [Feedback Generation](core/feedback-generation.md)
 
-## Grading Templates
+### Backend maintainer
 
-| Document | Description |
-|----------|-------------|
-| [Input/Output Template](templates/input_output.md) | Test command-line programs with stdin/stdout validation |
-| [Web Development Template](templates/web_dev.md) | Validate HTML, CSS, and JavaScript (36 test functions) |
-| [API Testing Template](templates/api_testing.md) | Test student-built web APIs via HTTP requests |
+- [Pipeline Architecture](core/pipeline-architecture.md)
+- [Pipeline Deep Dive](pipeline/README.md)
+- [Core Data Structures](architecture/core_structures.md)
+- [Sandbox Manager Internals](architecture/sandbox_manager.md)
 
-## Features
+### Template author
 
-| Document | Description |
-|----------|-------------|
-| [Deliberate Code Execution](features/deliberate_code_execution.md) | Execute code without grading (DCE feature) |
-| [Focus Feature](features/focus_feature.md) | Focus-based feedback highlighting high-impact improvements |
-| [Grading Engine](features/grading_engine.md) | Deep dive on the tree-based grading engine (traversal, weights, scoring) |
-| [Setup Config](features/setup_config_feature.md) | Preflight checks, required files, and setup commands |
-| [Command Resolver & Multi-Language Support](features/command_resolver.md) | Python, Java, Node.js, C and C++ support |
-| [Localization (i18n) System](features/localization.md) | Multi-language support (EN, PT-BR) for feedback and test reports |
-| [Pipeline Execution Tracking](architecture/pipeline_execution_tracking.md) | Step-by-step pipeline execution details |
-| [GitHub Action](guides/github_module.md) | GitHub Classroom integration |
+- [Template System](core/template-system.md)
+- [Input/Output Template](template-library/input_output.md)
+- [API Testing Template](template-library/api_testing.md)
+- [Web Development Template](template-library/web_dev.md)
 
-## Pipeline
+## Quick Access
 
-| Document | Description |
-|----------|-------------|
-| [Pipeline Overview](pipeline/README.md) | Architecture, PipelineExecution, assembly rules, step dependency table |
-| [Load Template Step](pipeline/01-load-template.md) | Loads the grading template with test functions |
-| [Build Tree Step](pipeline/02-build-tree.md) | Constructs the CriteriaTree from JSON config |
-| [Sandbox Step](pipeline/03-sandbox.md) | Creates the Docker sandbox and prepares the workspace |
-| [Pre-Flight Step](pipeline/04-pre-flight.md) | Validates required files and executes setup commands |
-| [Grade Step](pipeline/05-grade.md) | Executes tests and produces the scored ResultTree |
-| [Focus Step](pipeline/06-focus.md) | Ranks tests by impact on the final score |
-| [Feedback Step](pipeline/07-feedback.md) | Generates student-facing feedback reports |
-| [Export Step](pipeline/08-export.md) | Sends scores to external systems |
-
-## Architecture & Data Structures
-
-| Document | Description |
-|----------|-------------|
-| [Core Data Structures](architecture/core_structures.md) | CriteriaTree, ResultTree, Submission, GradingResult, and more |
-| [Sandbox Manager](architecture/sandbox_manager.md) | Container pooling, lifecycle, scaling, and security |
-| [Criteria Example](criteria_example.json) | Example criteria tree configuration (JSON) |
-
-## Project Management
-
-| Document | Description |
-|----------|-------------|
-| [Technical Debt Roadmap](roadmaps/TECHNICAL_DEBT_ROADMAP.md) | Refactoring plan for architecture cohesion and code quality |
+| Area | Entry Point |
+|------|-------------|
+| API reference | [API.md](API.md) |
+| Pipeline steps | [pipeline/README.md](pipeline/README.md) |
+| Features | [features/grading_engine.md](features/grading_engine.md) |
+| Development setup | [guides/development.md](guides/development.md) |
+| Documentation roadmap | [roadmaps/MKDOCS_DOCUMENTATION_ROADMAP.md](roadmaps/MKDOCS_DOCUMENTATION_ROADMAP.md) |

--- a/docs/roadmaps/MKDOCS_DOCUMENTATION_ROADMAP.md
+++ b/docs/roadmaps/MKDOCS_DOCUMENTATION_ROADMAP.md
@@ -1,0 +1,40 @@
+# MkDocs Documentation Roadmap
+
+This roadmap defines how we evolve the documentation into a complete teaching-oriented docs portal powered by MkDocs Material.
+
+## Problem statement
+
+The project already has rich technical docs, but discoverability and learning flow are fragmented. We need a structured docs site that serves both newcomers and maintainers while preserving technical depth.
+
+## Approach
+
+Build a layered documentation experience:
+
+1. **Guided learning path** for core concepts
+2. **Deep technical references** for architecture and pipeline internals
+3. **Operational docs workflow** (local preview, CI validation, GitHub Pages deployment)
+
+## Workstreams
+
+| Workstream | Goal | Status |
+|------------|------|--------|
+| Foundation | Add MkDocs config, theme, nav, local dev commands | In progress |
+| Core Concepts | Create didactic pages for pipeline, criteria, sandbox, templates, feedback | In progress |
+| Educational Quality | Add criteria-tree instructional standards guide | In progress |
+| CI Quality Gate | Validate links + strict MkDocs build in PR workflows | Pending |
+| Hosting | Publish docs to GitHub Pages from main | Pending |
+| Content Migration | Continue refining existing feature/architecture pages for consistent teaching pattern | Pending |
+
+## Definition of done
+
+1. Docs portal builds with `mkdocs build --strict`.
+2. Core concept pages are linked from home and nav.
+3. PRs that change docs run validation and site build checks.
+4. Main branch publishes the site automatically.
+5. Documentation style remains "what / why / how / example / pitfalls."
+
+## Next migration priorities
+
+1. Normalize older pages to the didactic page pattern.
+2. Add architecture diagrams for request and grading flows.
+3. Add contribution standards for docs writing and review.

--- a/docs/template-library/api_testing.md
+++ b/docs/template-library/api_testing.md
@@ -1,0 +1,115 @@
+# API Testing Template (`api_testing`)
+
+The API Testing template validates student-built web APIs by making HTTP requests to a running server inside a sandbox container and checking the responses.
+
+> **Template name for configs:** `api_testing`  
+> **Requires sandbox:** Yes  
+> **Communication:** HTTP requests to the containerized application via `SandboxContainer.make_request()`
+
+---
+
+## Test Functions
+
+### `health_check`
+
+Sends a GET request to an endpoint and verifies it returns HTTP status 200.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `endpoint` | string | ✓ | The endpoint to test (e.g., `"/health"`, `"/api/status"`) |
+
+**Scoring:** 100 if status code is 200, 0 otherwise.
+
+**Example:**
+```json
+{
+  "name": "health_check",
+  "parameters": { "endpoint": "/health" },
+  "weight": 100
+}
+```
+
+---
+
+### `check_response_json`
+
+Sends a GET request to an endpoint and verifies the JSON response contains a specific key-value pair.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `endpoint` | string | ✓ | The API endpoint to test |
+| `expected_key` | string | ✓ | JSON key to check in the response |
+| `expected_value` | any | ✓ | Expected value for that key |
+
+**Scoring:** 100 if the response is valid JSON and contains the expected key-value pair, 0 otherwise.
+
+**Example:**
+```json
+{
+  "name": "check_response_json",
+  "parameters": {
+    "endpoint": "/api/info",
+    "expected_key": "version",
+    "expected_value": "1.0"
+  },
+  "weight": 100
+}
+```
+
+---
+
+## Usage Example
+
+```json
+{
+  "external_assignment_id": "rest-api-assignment",
+  "template_name": "api_testing",
+  "languages": ["python", "node"],
+  "setup_config": {
+    "required_files": ["app.py"],
+    "setup_commands": [
+      { "name": "Install dependencies", "command": "pip install flask" },
+      { "name": "Start server", "command": "python app.py &" }
+    ]
+  },
+  "criteria_config": {
+    "base": {
+      "weight": 100,
+      "subjects": [
+        {
+          "subject_name": "API Endpoints",
+          "weight": 100,
+          "tests": [
+            {
+              "name": "health_check",
+              "parameters": { "endpoint": "/health" },
+              "weight": 30
+            },
+            {
+              "name": "check_response_json",
+              "parameters": {
+                "endpoint": "/api/data",
+                "expected_key": "status",
+                "expected_value": "ok"
+              },
+              "weight": 70
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+## How It Works
+
+Unlike the Input/Output and Web Dev templates, the API Testing template communicates with student code over HTTP:
+
+1. The sandbox starts the student's web server (via setup commands or the program itself)
+2. The sandbox container exposes a port
+3. Test functions send HTTP requests to `http://localhost:{port}{endpoint}`
+4. Responses are validated against expected values
+
+This means the student's submission must be a runnable web server that listens on the expected port.
+

--- a/docs/template-library/api_testing.md
+++ b/docs/template-library/api_testing.md
@@ -1,8 +1,8 @@
-# API Testing Template (`api_testing`)
+# API Testing Template (`api`)
 
 The API Testing template validates student-built web APIs by making HTTP requests to a running server inside a sandbox container and checking the responses.
 
-> **Template name for configs:** `api_testing`  
+> **Template name for configs:** `api`  
 > **Requires sandbox:** Yes  
 > **Communication:** HTTP requests to the containerized application via `SandboxContainer.make_request()`
 
@@ -63,7 +63,7 @@ Sends a GET request to an endpoint and verifies the JSON response contains a spe
 ```json
 {
   "external_assignment_id": "rest-api-assignment",
-  "template_name": "api_testing",
+  "template_name": "api",
   "languages": ["python", "node"],
   "setup_config": {
     "required_files": ["app.py"],

--- a/docs/template-library/input_output.md
+++ b/docs/template-library/input_output.md
@@ -1,0 +1,144 @@
+# Input/Output Template (`input_output`)
+
+The Input/Output template tests command-line programs by providing stdin inputs and validating stdout output. It requires a sandbox for code execution.
+
+> **Template name for configs:** `input_output`  
+> **Requires sandbox:** Yes  
+> **Supported languages:** Python, Java, Node.js, C++
+
+---
+
+## Test Functions
+
+### `expect_output`
+
+Executes a program with a series of stdin inputs and compares the program's stdout against an expected output string.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `inputs` | list[string] | ✓ | List of strings sent to stdin, each on a new line |
+| `expected_output` | string | ✓ | Exact string the program should print to stdout |
+| `program_command` | string | ✗ | Command to execute. Can be a plain string (e.g., `"python main.py"`), a dict for multi-language support, or `"CMD"` for auto-resolution based on submission language. |
+
+**Scoring:** 100 if output matches exactly (after trimming whitespace), 0 otherwise.
+
+**Error handling:** Automatically detects and reports:
+- Timeouts (infinite loops)
+- Compilation errors (Java/C++)
+- Runtime errors (crashes)
+- System errors (infrastructure failures)
+
+**Example:**
+```json
+{
+  "name": "expect_output",
+  "parameters": {
+    "inputs": ["Alice"],
+    "expected_output": "Hello, Alice!",
+    "program_command": "python3 main.py"
+  },
+  "weight": 100
+}
+```
+
+**Multi-language example** (auto-resolves command based on submission language):
+```json
+{
+  "name": "expect_output",
+  "parameters": {
+    "inputs": ["5", "3"],
+    "expected_output": "8",
+    "program_command": "CMD"
+  },
+  "weight": 100
+}
+```
+
+---
+
+### `dont_fail`
+
+Executes a program with a specific input and verifies it completes **without crashing**. The program's stdout is ignored — this test only validates that execution succeeds. Useful for testing error handling (e.g., sending invalid input).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `user_input` | string | ✗ | A string to send via stdin |
+| `program_command` | string | ✗ | Command to execute (same format as `expect_output`) |
+
+**Scoring:** 100 if program completes without error, 0 if it crashes/times out.
+
+**Example:**
+```json
+{
+  "name": "dont_fail",
+  "parameters": {
+    "user_input": "not_a_number",
+    "program_command": "python3 calculator.py"
+  },
+  "weight": 50
+}
+```
+
+---
+
+## Usage Example
+
+```json
+{
+  "external_assignment_id": "calculator-assignment",
+  "template_name": "input_output",
+  "languages": ["python", "java"],
+  "setup_config": {
+    "required_files": ["calculator.py"],
+    "setup_commands": []
+  },
+  "criteria_config": {
+    "base": {
+      "weight": 100,
+      "subjects": [
+        {
+          "subject_name": "Basic Operations",
+          "weight": 60,
+          "tests": [
+            {
+              "name": "expect_output",
+              "parameters": { "inputs": ["add", "5", "3"], "expected_output": "8", "program_command": "CMD" },
+              "weight": 50
+            },
+            {
+              "name": "expect_output",
+              "parameters": { "inputs": ["subtract", "10", "4"], "expected_output": "6", "program_command": "CMD" },
+              "weight": 50
+            }
+          ]
+        },
+        {
+          "subject_name": "Error Handling",
+          "weight": 40,
+          "tests": [
+            {
+              "name": "dont_fail",
+              "parameters": { "user_input": "invalid", "program_command": "CMD" },
+              "weight": 100
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+## Multi-Language Command Resolution
+
+When `program_command` is set to `"CMD"`, the autograder automatically resolves the execution command based on the submission's language:
+
+| Language | Resolved Command |
+|----------|-----------------|
+| Python | `python3 <main_file>` |
+| Java | `java <MainClass>` |
+| Node.js | `node <main_file>` |
+| C++ | `./<compiled_binary>` |
+
+This allows the same grading configuration to work across multiple languages without specifying language-specific commands.
+

--- a/docs/template-library/web_dev.md
+++ b/docs/template-library/web_dev.md
@@ -1,0 +1,423 @@
+# Web Development Template (`web_dev`)
+
+The Web Development template provides test functions for validating HTML, CSS, and JavaScript files. It does **not** require a sandbox — all validation is performed through static analysis using BeautifulSoup and regex pattern matching.
+
+> **Template name for configs:** `web_dev`  
+> **Requires sandbox:** No  
+> **File types:** HTML, CSS, JavaScript
+
+---
+
+## HTML Tests
+
+### `has_tag`
+Checks if a specific HTML tag appears a minimum number of times.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tag` | string | The HTML tag to search for (e.g., `"div"`, `"header"`) |
+| `required_count` | integer | Minimum number of occurrences required |
+
+```json
+{ "name": "has_tag", "parameters": { "tag": "header", "required_count": 1 }, "weight": 50 }
+```
+
+---
+
+### `has_class`
+Checks for CSS classes in the HTML, with **wildcard support** (e.g., `col-*` matches `col-md-6`, `col-lg-4`, etc.).
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `class_names` | list[string] | Class names to search for. Wildcards (`*`) supported. |
+| `required_count` | integer | Minimum total number of matching class occurrences |
+
+```json
+{ "name": "has_class", "parameters": { "class_names": ["col-*", "container"], "required_count": 3 }, "weight": 50 }
+```
+
+---
+
+### `has_attribute`
+Checks if a specific HTML attribute is present on any tag a minimum number of times.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `attribute` | string | The attribute to search for (e.g., `"alt"`, `"href"`) |
+| `required_count` | integer | Minimum number of occurrences required |
+
+```json
+{ "name": "has_attribute", "parameters": { "attribute": "alt", "required_count": 3 }, "weight": 30 }
+```
+
+---
+
+### `has_forbidden_tag`
+Checks for a **forbidden** HTML tag and penalizes if found.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tag` | string | The forbidden tag (e.g., `"marquee"`, `"blink"`) |
+
+```json
+{ "name": "has_forbidden_tag", "parameters": { "tag": "marquee" }, "weight": 100 }
+```
+
+---
+
+### `check_bootstrap_linked`
+Verifies that the Bootstrap framework (CSS or JS) is linked in the HTML file.
+
+*No parameters.*
+
+```json
+{ "name": "check_bootstrap_linked", "parameters": {}, "weight": 100 }
+```
+
+---
+
+### `check_bootstrap_usage`
+**Penalty test** — checks if Bootstrap is being used. Scores 0 if found, 100 if not. Use in penalty categories to deduct points for using Bootstrap when it's not allowed.
+
+*No parameters.*
+
+---
+
+### `check_internal_links`
+Verifies that anchor links (`<a href="#id">`) point to valid element IDs within the document.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `required_count` | integer | Minimum number of valid internal links |
+
+---
+
+### `check_internal_links_to_article`
+Verifies that anchor links point to IDs on `<article>` elements specifically.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `required_count` | integer | Minimum number of valid links to `<article>` elements |
+
+---
+
+### `check_no_unclosed_tags`
+Detects HTML tags that were opened but not properly closed. Ignores void elements (`<br>`, `<img>`, etc.).
+
+*No parameters.*
+
+---
+
+### `check_no_inline_styles`
+Ensures no inline `style="..."` attributes are used in the HTML.
+
+*No parameters.*
+
+---
+
+### `uses_semantic_tags`
+Checks if the HTML uses at least one semantic tag (`<article>`, `<section>`, `<nav>`, `<aside>`, `<figure>`).
+
+*No parameters.*
+
+---
+
+### `check_css_linked`
+Verifies an external CSS stylesheet is linked via `<link rel="stylesheet">`.
+
+*No parameters.*
+
+---
+
+### `check_headings_sequential`
+Verifies heading levels (`<h1>` through `<h6>`) don't skip levels (e.g., `<h1>` → `<h3>` without `<h2>` is flagged).
+
+*No parameters.*
+
+---
+
+### `check_all_images_have_alt`
+Checks that all `<img>` tags have a non-empty `alt` attribute. Scores proportionally.
+
+*No parameters.*
+
+---
+
+### `check_html_direct_children`
+Ensures the only direct children of `<html>` are `<head>` and `<body>`.
+
+*No parameters.*
+
+---
+
+### `check_tag_not_inside`
+Verifies a specific tag is NOT nested inside another specific tag.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `child_tag` | string | The tag that should not be nested |
+| `parent_tag` | string | The parent tag to check inside |
+
+```json
+{ "name": "check_tag_not_inside", "parameters": { "child_tag": "div", "parent_tag": "span" }, "weight": 50 }
+```
+
+---
+
+### `check_head_details`
+Verifies a specific tag exists inside the `<head>` section.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `detail_tag` | string | Tag to look for (e.g., `"title"`, `"meta"`) |
+
+---
+
+### `check_attribute_and_value`
+Checks if a tag has a specific attribute with a specific value.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tag` | string | The HTML tag |
+| `attribute` | string | The attribute name |
+| `value` | string | The expected attribute value |
+
+```json
+{ "name": "check_attribute_and_value", "parameters": { "tag": "html", "attribute": "lang", "value": "pt-BR" }, "weight": 30 }
+```
+
+---
+
+### `link_points_to_page_with_query_param`
+Checks for anchor tags linking to a specific page with a required query string parameter.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `target_page` | string | Expected page (e.g., `"details.html"`) |
+| `query_param` | string | Required query parameter name (e.g., `"id"`) |
+| `required_count` | integer | Minimum number of valid links |
+
+---
+
+## CSS Tests
+
+### `css_uses_property`
+Checks if a specific CSS property-value pair exists in the stylesheet.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `prop` | string | CSS property (e.g., `"display"`) |
+| `value` | string | Expected value (e.g., `"flex"`) |
+
+```json
+{ "name": "css_uses_property", "parameters": { "prop": "display", "value": "flex" }, "weight": 50 }
+```
+
+---
+
+### `has_style`
+Checks if a CSS style rule appears a minimum number of times.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `style` | string | The CSS property to count (e.g., `"margin"`) |
+| `count` | integer | Minimum number of occurrences |
+
+---
+
+### `count_over_usage`
+**Penalty test** — penalizes if a specific text string appears more than a maximum number of times in CSS.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | The text to count |
+| `max_allowed` | integer | Maximum allowed occurrences |
+
+---
+
+### `check_id_selector_over_usage`
+**Penalty test** — counts CSS ID selectors (`#id`) and penalizes if they exceed a maximum.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `max_allowed` | integer | Maximum number of ID selectors allowed |
+
+---
+
+### `uses_relative_units`
+Checks if the CSS uses relative units (`em`, `rem`, `%`, `vh`, `vw`).
+
+*No parameters.*
+
+---
+
+### `check_media_queries`
+Checks if the CSS contains `@media` queries for responsive design.
+
+*No parameters.*
+
+---
+
+### `check_flexbox_usage`
+Checks if Flexbox properties (`display: flex` or `flex-*`) are used.
+
+*No parameters.*
+
+---
+
+## JavaScript Tests
+
+### `js_uses_feature`
+Performs a simple string search to check if a JavaScript feature/keyword is present.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `feature` | string | The string to search for (e.g., `"addEventListener"`) |
+
+```json
+{ "name": "js_uses_feature", "parameters": { "feature": "addEventListener" }, "weight": 50 }
+```
+
+---
+
+### `uses_forbidden_method`
+**Penalty test** — checks for a forbidden JavaScript method and penalizes if found.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `method` | string | The forbidden method name (e.g., `"alert"`) |
+
+---
+
+### `count_global_vars`
+**Penalty test** — counts top-level `var`/`let`/`const` declarations and penalizes if too many.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `max_allowed` | integer | Maximum global variables allowed |
+
+---
+
+### `js_uses_query_string_parsing`
+Checks if the JS code uses URL query string parsing (`URLSearchParams` or `window.location.search`).
+
+*No parameters.*
+
+---
+
+### `js_has_json_array_with_id`
+Checks for a JS array of objects where each object has a specific required key.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `required_key` | string | Key that must exist in each object (e.g., `"id"`) |
+| `min_items` | integer | Minimum number of items expected |
+
+---
+
+### `js_uses_dom_manipulation`
+Checks for DOM manipulation method calls in the JavaScript code.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `methods` | list[string] | Methods to search for (e.g., `["createElement", "appendChild"]`) |
+| `required_count` | integer | Minimum total occurrences |
+
+```json
+{ "name": "js_uses_dom_manipulation", "parameters": { "methods": ["createElement", "appendChild", "textContent"], "required_count": 5 }, "weight": 60 }
+```
+
+---
+
+### `has_no_js_framework`
+**Penalty test** — detects forbidden JS frameworks (React, Vue, Angular) across HTML and JS files.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `html_file` | string | HTML file to check (e.g., `"index.html"`) |
+| `js_file` | string | JS file to check (e.g., `"script.js"`) |
+
+---
+
+## Project Structure Tests
+
+### `check_dir_exists`
+Checks if a directory exists in the submission by looking for files with that path prefix.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `dir_path` | string | Directory path to check (e.g., `"css/"`) |
+
+---
+
+### `check_project_structure`
+Checks if a specific file path exists in the submission.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `expected_structure` | string | Expected file path (e.g., `"css/styles.css"`) |
+
+---
+
+### `Count Unused Css Classes`
+Finds CSS classes defined in the stylesheet but not used in HTML, or vice versa.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `html_file` | string | HTML filename (e.g., `"index.html"`) |
+| `css_file` | string | CSS filename (e.g., `"styles.css"`) |
+
+---
+
+## Usage Example
+
+```json
+{
+  "external_assignment_id": "web-portfolio",
+  "template_name": "web_dev",
+  "languages": ["python"],
+  "criteria_config": {
+    "base": {
+      "weight": 100,
+      "subjects": [
+        {
+          "subject_name": "HTML Structure",
+          "weight": 40,
+          "tests": [
+            { "name": "has_tag", "parameters": { "tag": "header", "required_count": 1 }, "weight": 30 },
+            { "name": "has_tag", "parameters": { "tag": "nav", "required_count": 1 }, "weight": 20 },
+            { "name": "uses_semantic_tags", "parameters": {}, "weight": 20 },
+            { "name": "check_all_images_have_alt", "parameters": {}, "weight": 30 }
+          ]
+        },
+        {
+          "subject_name": "CSS Styling",
+          "weight": 35,
+          "tests": [
+            { "name": "check_css_linked", "parameters": {}, "weight": 20 },
+            { "name": "check_flexbox_usage", "parameters": {}, "weight": 30 },
+            { "name": "check_media_queries", "parameters": {}, "weight": 30 },
+            { "name": "uses_relative_units", "parameters": {}, "weight": 20 }
+          ]
+        },
+        {
+          "subject_name": "JavaScript",
+          "weight": 25,
+          "tests": [
+            { "name": "js_uses_feature", "parameters": { "feature": "addEventListener" }, "weight": 50 },
+            { "name": "js_uses_dom_manipulation", "parameters": { "methods": ["createElement", "appendChild"], "required_count": 3 }, "weight": 50 }
+          ]
+        }
+      ]
+    },
+    "penalty": {
+      "weight": -20,
+      "tests": [
+        { "name": "check_no_inline_styles", "parameters": {}, "weight": 50 },
+        { "name": "has_no_js_framework", "parameters": { "html_file": "index.html", "js_file": "script.js" }, "weight": 50 }
+      ]
+    }
+  }
+}
+```
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,7 +39,6 @@ nav:
   - Home: index.md
   - Getting Started:
       - Local Docs Development: getting-started/mkdocs-local-development.md
-      - Development Guide: guides/development.md
   - Core Concepts:
       - Pipeline Architecture: core/pipeline-architecture.md
       - Criteria Tree: core/criteria-tree.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,86 @@
+site_name: Autograder Documentation
+site_description: Educational-standards-driven autograding platform documentation
+site_url: https://webtech-network.github.io/autograder/
+repo_url: https://github.com/webtech-network/autograder
+repo_name: webtech-network/autograder
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  language: en
+  features:
+    - navigation.sections
+    - navigation.tabs
+    - navigation.top
+    - content.code.copy
+    - search.suggest
+    - search.highlight
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Local Docs Development: getting-started/mkdocs-local-development.md
+      - Development Guide: guides/development.md
+  - Core Concepts:
+      - Pipeline Architecture: core/pipeline-architecture.md
+      - Criteria Tree: core/criteria-tree.md
+      - Sandbox Management: core/sandbox-management.md
+      - Template System: core/template-system.md
+      - Feedback Generation: core/feedback-generation.md
+      - Educational Criteria Design: guides/criteria-tree-educational-standards.md
+  - API:
+      - REST API Reference: API.md
+  - Pipeline Deep Dive:
+      - Overview: pipeline/README.md
+      - 01 Load Template: pipeline/01-load-template.md
+      - 02 Build Tree: pipeline/02-build-tree.md
+      - 03 Sandbox: pipeline/03-sandbox.md
+      - 04 Pre Flight: pipeline/04-pre-flight.md
+      - 04.5 AI Batch: pipeline/04.5-ai-batch.md
+      - 05 Grade: pipeline/05-grade.md
+      - 06 Focus: pipeline/06-focus.md
+      - 07 Feedback: pipeline/07-feedback.md
+      - 08 Export: pipeline/08-export.md
+  - Architecture Reference:
+      - Core Structures: architecture/core_structures.md
+      - Pipeline Execution Tracking: architecture/pipeline_execution_tracking.md
+      - Sandbox Manager Internals: architecture/sandbox_manager.md
+      - Web Module: architecture/web_module.md
+  - Templates:
+      - Input Output Template: template-library/input_output.md
+      - API Testing Template: template-library/api_testing.md
+      - Web Development Template: template-library/web_dev.md
+  - Features:
+      - Grading Engine: features/grading_engine.md
+      - Focus Feature: features/focus_feature.md
+      - Deliberate Code Execution: features/deliberate_code_execution.md
+      - Setup Config: features/setup_config_feature.md
+      - Command Resolver: features/command_resolver.md
+      - Localization: features/localization.md
+  - Guides:
+      - Development Guide: guides/development.md
+      - Criteria Configuration Examples: guides/criteria_configuration_examples.md
+      - GitHub Module: guides/github_module.md
+  - Roadmaps:
+      - MkDocs Documentation Roadmap: roadmaps/MKDOCS_DOCUMENTATION_ROADMAP.md
+      - Feature Roadmap: roadmaps/FEATURE_ROADMAP.md
+      - Technical Debt Roadmap: roadmaps/TECHNICAL_DEBT_ROADMAP.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+mkdocs>=1.6,<2.0
+mkdocs-material>=9.6,<10.0
+pymdown-extensions>=10.0,<11.0


### PR DESCRIPTION
## Summary
- introduce MkDocs Material configuration and strict docs build dependencies
- add didactic core concept pages for pipeline architecture, criteria tree, sandbox management, template system, and feedback generation
- add educational criteria-tree standards guide and MkDocs migration roadmap
- add docs CI/build updates and GitHub Pages deployment workflow
- add template-library docs mirror for MkDocs compatibility

## Validation
- python scripts/validate_docs.py
- mkdocs build --strict