### PR TITLE
docs: make getting started a real grading workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The **SandboxManager** provides secure, isolated execution environments:
 - **Automatic Lifecycle**: TTL management, health checks, and cleanup
 - **Resource Control**: Memory limits, timeouts, and isolation
 
-#### Template System
+#### Template Library
 
 Templates provide test functions for different assignment contexts:
 

--- a/docs/core/template-library.md
+++ b/docs/core/template-library.md
@@ -1,4 +1,4 @@
-# Template System
+# Template Library
 
 ## What it is
 

--- a/docs/getting-started/mkdocs-local-development.md
+++ b/docs/getting-started/mkdocs-local-development.md
@@ -1,40 +1,117 @@
-# Local Docs Development (MkDocs)
+# Run Your First Grading Workflow
 
-This project uses **MkDocs Material** to publish the documentation website.
+This quickstart walks you through one complete grading cycle:
 
-## Run locally
+1. start the API
+2. create a grading configuration
+3. submit student code
+4. fetch the graded result
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+- Python available on your machine
+- Project dependencies installed (`pip install -r requirements.txt`)
+
+## 1) Start Autograder
 
 ```bash
-pip install -r requirements-docs.txt
-mkdocs serve
+make start-autograder
 ```
 
-Open `http://127.0.0.1:8000` to preview changes with live reload.
+When ready, the API is available at `http://localhost:8080`.
 
-## Build locally
+You can check health:
 
 ```bash
-mkdocs build --strict
+curl http://localhost:8080/api/v1/health
 ```
 
-`--strict` turns warnings into errors, which helps catch broken navigation or links before opening a PR.
+## 2) Create a grading configuration
 
-## Where to edit
+```bash
+curl -X POST http://localhost:8080/api/v1/configs \
+  -H "Content-Type: application/json" \
+  -d '{
+    "external_assignment_id": "demo-assignment-1",
+    "template_name": "input_output",
+    "criteria_config": {
+      "base": {
+        "weight": 100,
+        "subjects": [
+          {
+            "subject_name": "Functionality",
+            "weight": 100,
+            "tests": [
+              {
+                "name": "expect_output",
+                "weight": 100,
+                "parameters": {
+                  "inputs": ["Alice"],
+                  "expected_output": "Hello, Alice!",
+                  "program_command": "python3 main.py"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "languages": ["python"],
+    "setup_config": {
+      "required_files": ["main.py"],
+      "setup_commands": []
+    },
+    "include_feedback": true,
+    "feedback_config": {
+      "general": {
+        "report_title": "Evaluation Report",
+        "show_score": true,
+        "show_passed_tests": false,
+        "add_report_summary": true
+      }
+    }
+  }'
+```
 
-- Main landing page: `docs/index.md`
-- Core concept pages: `docs/core/`
-- Pipeline deep dives: `docs/pipeline/`
-- Architecture references: `docs/architecture/`
-- Roadmaps: `docs/roadmaps/`
+## 3) Submit a student solution
 
-## Documentation standards
+```bash
+curl -X POST http://localhost:8080/api/v1/submissions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "external_assignment_id": "demo-assignment-1",
+    "external_user_id": "student-1",
+    "username": "student_1",
+    "language": "python",
+    "files": [
+      {
+        "filename": "main.py",
+        "content": "name = input().strip()\nprint(f\"Hello, {name}!\")"
+      }
+    ]
+  }'
+```
 
-Every new technical page should follow this teaching pattern:
+Copy the returned `id` from the response. That is your `submission_id`.
 
-1. **What it is**
-2. **Why it matters**
-3. **How it works**
-4. **Concrete example**
-5. **Common mistakes**
+## 4) Poll for the result
 
-For rubric quality guidance, use [Educational Criteria Design](../guides/criteria-tree-educational-standards.md).
+```bash
+curl http://localhost:8080/api/v1/submissions/<submission_id>
+```
+
+When grading finishes, response status becomes `completed`, and you will get:
+
+- `final_score`
+- `feedback`
+- `result_tree`
+- `focus`
+
+## What you just exercised
+
+You ran the full core flow:
+
+`LOAD_TEMPLATE -> BUILD_TREE -> SANDBOX -> PRE_FLIGHT -> GRADE -> FOCUS -> FEEDBACK`
+
+To understand each stage in depth, continue with [Pipeline Architecture](../core/pipeline-architecture.md).

--- a/docs/guides/docs-site-development.md
+++ b/docs/guides/docs-site-development.md
@@ -1,0 +1,32 @@
+# Docs Site Development (MkDocs)
+
+This project uses **MkDocs Material** to publish the documentation website.
+
+## Run locally
+
+```bash
+pip install -r requirements-docs.txt
+mkdocs serve
+```
+
+Open `http://127.0.0.1:8000` to preview changes with live reload.
+
+## Build locally
+
+```bash
+mkdocs build --strict
+```
+
+`--strict` turns warnings into errors, which helps catch broken navigation or links before opening a PR.
+
+## Documentation standards
+
+Every new technical page should follow this teaching pattern:
+
+1. **What it is**
+2. **Why it matters**
+3. **How it works**
+4. **Concrete example**
+5. **Common mistakes**
+
+For rubric quality guidance, use [Educational Criteria Design](criteria-tree-educational-standards.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ This documentation is organized to be both practical for first-time users and de
 1. [Pipeline Architecture](core/pipeline-architecture.md)
 2. [Criteria Tree](core/criteria-tree.md)
 3. [Sandbox Management](core/sandbox-management.md)
-4. [Template System](core/template-system.md)
+4. [Template Library](core/template-library.md)
 5. [Feedback Generation](core/feedback-generation.md)
 
 ## Learning Paths
@@ -27,7 +27,7 @@ This documentation is organized to be both practical for first-time users and de
 
 ### Template author
 
-- [Template System](core/template-system.md)
+- [Template Library](core/template-library.md)
 - [Input/Output Template](template-library/input_output.md)
 - [API Testing Template](template-library/api_testing.md)
 - [Web Development Template](template-library/web_dev.md)

--- a/docs/roadmaps/FEATURE_ROADMAP.md
+++ b/docs/roadmaps/FEATURE_ROADMAP.md
@@ -93,7 +93,7 @@ How this integrates with the existing grading template strategy (whether it beco
 
 #### Open Challenges
 
-- **Integration with the template system.** How static analysis tests fit into the existing grading template strategy needs further discussion — whether as a new template type, an extension to existing templates, or a separate layer that can be composed with any template.
+- **Integration with the Template Library.** How static analysis tests fit into the existing grading template strategy needs further discussion — whether as a new template type, an extension to existing templates, or a separate layer that can be composed with any template.
 - **Balancing language-agnostic and language-specific checks.** The hybrid approach needs a clear structure so that educators can configure both general and language-specific checks without the system becoming overly complex.
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,7 +44,7 @@ nav:
       - Pipeline Architecture: core/pipeline-architecture.md
       - Criteria Tree: core/criteria-tree.md
       - Sandbox Management: core/sandbox-management.md
-      - Template System: core/template-system.md
+      - Template Library: core/template-library.md
       - Feedback Generation: core/feedback-generation.md
       - Educational Criteria Design: guides/criteria-tree-educational-standards.md
   - API:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,7 +38,8 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Getting Started:
-      - Local Docs Development: getting-started/mkdocs-local-development.md
+      - Run Your First Grading Workflow: getting-started/mkdocs-local-development.md
+      - Development Guide: guides/development.md
   - Core Concepts:
       - Pipeline Architecture: core/pipeline-architecture.md
       - Criteria Tree: core/criteria-tree.md
@@ -77,6 +78,7 @@ nav:
       - Localization: features/localization.md
   - Guides:
       - Development Guide: guides/development.md
+      - Docs Site Development: guides/docs-site-development.md
       - Criteria Configuration Examples: guides/criteria_configuration_examples.md
       - GitHub Module: guides/github_module.md
   - Roadmaps:


### PR DESCRIPTION
## Summary
- replace docs-first getting started page with a true first grading run
- guide users through API startup, config creation, submission, and result retrieval
- move MkDocs authoring instructions to a dedicated docs contributor guide
- update MkDocs nav labels accordingly

## Validation
- python scripts/validate_docs.py
- mkdocs build --strict