### PR TITLE
(feat) new I/O test : Expect File Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Tests command-line programs by providing inputs and validating outputs.
 | Test Name          | Description                                             | Key Parameters                               |
 |--------------------|---------------------------------------------------------|----------------------------------------------|
 | `expect_output`    | Execute program with inputs and verify output           | `inputs`, `expected_output`, `program_command` |
+| `expect_file_artifact` | Execute program and validate a generated output file | `artifact_path`, `expected_content`, `program_command` |
 | `dont_fail`        | Validates that a program does not crash on a given input | `inputs`, `program_command`                 |
 | `forbidden_import` | Analyzes a file looking for specified libraries imports | `forbidden_imports`        |
 

--- a/autograder/template_library/input_output.py
+++ b/autograder/template_library/input_output.py
@@ -39,7 +39,7 @@ class BaseExecutionTest(TestFunction):
         command = ' '.join(inputs) if isinstance(inputs, list) else str(inputs)
         return sandbox.run_command(command)
 
-    def check_for_base_errors(self, output) -> TestResult:
+    def check_for_base_errors(self, output, **kwargs) -> TestResult:
         """
         Checks for Timeout, Compilation Error, or Runtime Error in the sandbox output.
         Returns a TestResult with score 0.0 if an error is found, or None if successful.
@@ -119,7 +119,7 @@ class ExpectOutputTest(BaseExecutionTest):
             )
 
             # Check for generic execution failures
-            error_result = self.check_for_base_errors(output)
+            error_result = self.check_for_base_errors(output, locale=kwargs.get("locale"))
             if error_result:
                 return error_result
 
@@ -191,7 +191,7 @@ class DontFailTest(BaseExecutionTest):
             )
 
             # Check for generic execution failures
-            error_result = self.check_for_base_errors(output)
+            error_result = self.check_for_base_errors(output, locale=kwargs.get("locale"))
             if error_result:
                 return error_result
 
@@ -209,6 +209,130 @@ class DontFailTest(BaseExecutionTest):
                 report=t("io.expect_output.report.internal_error", locale=kwargs.get("locale"), error=str(e))
             )
 
+
+
+# ===============================================================
+# TestFunction for File Artifact Validation
+# ===============================================================
+
+class ExpectFileArtifactTest(BaseExecutionTest):
+    """
+    Tests a command-line program by running it, then extracting a generated
+    file from the sandbox and comparing its content against expected values.
+
+    Supports exact, contains, and regex matching modes.
+    """
+
+    @property
+    def name(self):
+        return "expect_file_artifact"
+
+    @property
+    def description(self):
+        return t("io.expect_file_artifact.description")
+
+    @property
+    def required_file(self):
+        return None
+
+    @property
+    def parameter_description(self):
+        return [
+            ParamDescription("program_command", t("io.expect_file_artifact.params.program_command"), "string or dict"),
+            ParamDescription("artifact_path", t("io.expect_file_artifact.params.artifact_path"), "string"),
+            ParamDescription("expected_content", t("io.expect_file_artifact.params.expected_content"), "string"),
+            ParamDescription("match_mode", t("io.expect_file_artifact.params.match_mode"), "string"),
+            ParamDescription("inputs", t("io.expect_file_artifact.params.inputs"), "list of strings"),
+            ParamDescription("normalization", t("io.expect_file_artifact.params.normalization"), "boolean"),
+        ]
+
+    @staticmethod
+    def _validate_artifact_path(artifact_path: str) -> Optional[str]:
+        """Return an error message if the path is unsafe, else None."""
+        if not artifact_path:
+            return "artifact_path is required"
+        if artifact_path.startswith("/") or ".." in artifact_path.split("/"):
+            return f"Invalid artifact_path (absolute or traversal): {artifact_path}"
+        return None
+
+    @staticmethod
+    def _normalize(text: str) -> str:
+        """Normalize line endings and strip trailing whitespace per line."""
+        lines = text.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+        return "\n".join(line.rstrip() for line in lines).strip()
+
+    @staticmethod
+    def _match(actual: str, expected: str, mode: str) -> bool:
+        if mode == "contains":
+            return expected in actual
+        if mode == "regex":
+            return bool(re.search(expected, actual))
+        return actual == expected
+
+    def execute(self, files, sandbox: SandboxContainer, *args,
+                program_command: Optional[str] = None,
+                artifact_path: str = "",
+                expected_content: str = "",
+                match_mode: str = "exact",
+                inputs: list = None,
+                normalization: bool = True,
+                **kwargs) -> TestResult:
+        locale = kwargs.get("locale")
+
+        # Validate artifact_path
+        path_error = self._validate_artifact_path(artifact_path)
+        if path_error:
+            return TestResult(test_name=self.name, score=0.0,
+                              report=t("io.expect_file_artifact.report.invalid_path", locale=locale, error=path_error))
+
+        # Validate match_mode
+        if match_mode not in ("exact", "contains", "regex"):
+            return TestResult(test_name=self.name, score=0.0,
+                              report=t("io.expect_file_artifact.report.invalid_match_mode", locale=locale, mode=match_mode))
+
+        # Pre-compile regex to catch bad patterns early
+        if match_mode == "regex":
+            try:
+                re.compile(expected_content)
+            except re.error as e:
+                return TestResult(test_name=self.name, score=0.0,
+                                  report=t("io.expect_file_artifact.report.invalid_regex", locale=locale, error=str(e)))
+
+        # Execute student program
+        try:
+            output = self.run_sandbox_execution(sandbox=sandbox, inputs=inputs, program_command=program_command)
+            error_result = self.check_for_base_errors(output, locale=locale)
+            if error_result:
+                return error_result
+        except (ValueError, TimeoutError, RuntimeError) as e:
+            return TestResult(test_name=self.name, score=0.0,
+                              report=t("io.expect_output.report.internal_error", locale=locale, error=str(e)))
+
+        # Extract artifact
+        full_path = f"/app/{artifact_path}"
+        try:
+            extracted = sandbox.extract_file(full_path)
+        except FileNotFoundError:
+            return TestResult(test_name=self.name, score=0.0,
+                              report=t("io.expect_file_artifact.report.file_not_found", locale=locale, path=artifact_path))
+        except (ValueError, RuntimeError) as e:
+            return TestResult(test_name=self.name, score=0.0,
+                              report=t("io.expect_file_artifact.report.extraction_error", locale=locale, error=str(e)))
+
+        # Compare content
+        actual = extracted.content_text
+        expected = expected_content
+        if normalization:
+            actual = self._normalize(actual)
+            expected = self._normalize(expected)
+
+        if self._match(actual, expected, match_mode):
+            return TestResult(test_name=self.name, score=100.0,
+                              report=t("io.expect_file_artifact.report.success", locale=locale, path=artifact_path))
+
+        return TestResult(test_name=self.name, score=0.0,
+                          report=t("io.expect_file_artifact.report.mismatch", locale=locale,
+                                   path=artifact_path, expected=expected, actual=actual))
 
 
 # ===============================================================
@@ -396,6 +520,7 @@ class InputOutputTemplate(Template):
         self.tests = {
             "expect_output": ExpectOutputTest(),
             "dont_fail": DontFailTest(),
+            "expect_file_artifact": ExpectFileArtifactTest(),
             "forbidden_import": ForbiddenImportTest(),
         }
 

--- a/autograder/translations/en.json
+++ b/autograder/translations/en.json
@@ -467,6 +467,26 @@
     "template": {
       "name": "Input/Output",
       "description": "A template for evaluating assignments based on command-line input and output."
+    },
+    "expect_file_artifact": {
+      "description": "Executes the student program, then extracts a generated file from the sandbox and validates its content against expected values.",
+      "params": {
+        "program_command": "(Optional) Command to run the program. Can be a string or dict (multi-lang).",
+        "artifact_path": "Relative path (under /app) of the file the program must generate (e.g. 'output.txt').",
+        "expected_content": "The expected file content or pattern to match against.",
+        "match_mode": "Comparison mode: 'exact' (default), 'contains', or 'regex'.",
+        "inputs": "List of strings to be sent to the program via stdin.",
+        "normalization": "Whether to normalize line endings and trim trailing whitespace (default: true)."
+      },
+      "report": {
+        "success": "Success: Artifact '{path}' matches expected content.",
+        "mismatch": "FAILURE: Content mismatch in artifact '{path}'.\nExpected:\n{expected}\nActual:\n{actual}",
+        "file_not_found": "FAILURE: Expected artifact '{path}' was not found. Make sure your program creates this file.",
+        "extraction_error": "FAILURE: Could not read artifact from sandbox.\nDetails: {error}",
+        "invalid_path": "CONFIGURATION ERROR: Invalid artifact path.\nDetails: {error}",
+        "invalid_match_mode": "CONFIGURATION ERROR: Invalid match_mode '{mode}'. Must be 'exact', 'contains', or 'regex'.",
+        "invalid_regex": "CONFIGURATION ERROR: Invalid regex pattern.\nDetails: {error}"
+      }
     }
   },
   "api_testing": {

--- a/autograder/translations/pt_br.json
+++ b/autograder/translations/pt_br.json
@@ -467,6 +467,26 @@
     "template": {
       "name": "Entrada/Saída (I/O)",
       "description": "Um modelo para avaliar trabalhos com base na entrada e saída de linha de comando."
+    },
+    "expect_file_artifact": {
+      "description": "Executa o programa do aluno, extrai um arquivo gerado do sandbox e valida seu conteúdo contra os valores esperados.",
+      "params": {
+        "program_command": "(Opcional) Comando para executar o programa. Pode ser uma string ou dict (multi-idioma).",
+        "artifact_path": "Caminho relativo (sob /app) do arquivo que o programa deve gerar (ex: 'output.txt').",
+        "expected_content": "O conteúdo esperado do arquivo ou padrão para comparação.",
+        "match_mode": "Modo de comparação: 'exact' (padrão), 'contains' ou 'regex'.",
+        "inputs": "Lista de strings a serem enviadas para o programa via stdin.",
+        "normalization": "Se deve normalizar quebras de linha e remover espaços em branco no final (padrão: true)."
+      },
+      "report": {
+        "success": "Sucesso: O artefato '{path}' corresponde ao conteúdo esperado.",
+        "mismatch": "FALHA: Conteúdo divergente no artefato '{path}'.\nEsperado:\n{expected}\nObtido:\n{actual}",
+        "file_not_found": "FALHA: O artefato esperado '{path}' não foi encontrado. Verifique se o seu programa cria este arquivo.",
+        "extraction_error": "FALHA: Não foi possível ler o artefato do sandbox.\nDetalhes: {error}",
+        "invalid_path": "ERRO DE CONFIGURAÇÃO: Caminho de artefato inválido.\nDetalhes: {error}",
+        "invalid_match_mode": "ERRO DE CONFIGURAÇÃO: match_mode '{mode}' inválido. Deve ser 'exact', 'contains' ou 'regex'.",
+        "invalid_regex": "ERRO DE CONFIGURAÇÃO: Padrão regex inválido.\nDetalhes: {error}"
+      }
     }
   },
   "api_testing": {

--- a/docs/templates/input_output.md
+++ b/docs/templates/input_output.md
@@ -56,6 +56,84 @@ Executes a program with a series of stdin inputs and compares the program's stdo
 
 ---
 
+### `expect_file_artifact`
+
+Executes a program and then extracts a generated file from the sandbox container, comparing its content against an expected value. Useful for assignments where students must produce output files (e.g., reports, sorted data, metrics).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `artifact_path` | string | ✓ | Relative path under `/app` of the file the program must generate (e.g., `output.txt`) |
+| `expected_content` | string | ✓ | Expected file content or pattern to match against |
+| `program_command` | string | ✗ | Command to execute (same format as `expect_output`) |
+| `match_mode` | string | ✗ | `exact` (default), `contains`, or `regex` |
+| `inputs` | list[string] | ✗ | List of strings sent to stdin before extraction |
+| `normalization` | boolean | ✗ | Normalize line endings and trim trailing whitespace (default: `true`) |
+
+**Scoring:** 100 if file content matches, 0 otherwise.
+
+**Error handling:** Inherits all execution error detection from `expect_output` (timeouts, compilation errors, runtime errors), plus:
+- Missing artifact file
+- Artifact extraction failure
+- Invalid regex pattern
+- Invalid artifact path (absolute or traversal paths are rejected)
+
+**Artifact path conventions:**
+- Paths are relative to `/app` (the sandbox working directory)
+- Absolute paths (`/etc/passwd`) and traversal paths (`../secret`) are rejected
+- The file must be a regular file (not a directory or symlink)
+- Maximum extracted file size: 1 MB
+
+**Exact match example:**
+```json
+{
+  "name": "expect_file_artifact",
+  "parameters": {
+    "inputs": ["1000"],
+    "program_command": {
+      "python": "python3 main.py",
+      "java": "java Main",
+      "node": "node main.js",
+      "cpp": "./main"
+    },
+    "artifact_path": "matricula_selecao.txt",
+    "match_mode": "exact",
+    "expected_content": "comparacoes: 10\nmovimentacoes: 4\ntempo: 0.001s"
+  },
+  "weight": 100
+}
+```
+
+**Regex match example** (for variable values like execution time):
+```json
+{
+  "name": "expect_file_artifact",
+  "parameters": {
+    "inputs": ["1000"],
+    "program_command": "CMD",
+    "artifact_path": "matricula_insercao.txt",
+    "match_mode": "regex",
+    "expected_content": "comparacoes:\\s*\\d+\\s+movimentacoes:\\s*\\d+\\s+tempo:\\s*[0-9.]+s"
+  },
+  "weight": 100
+}
+```
+
+**Contains match example:**
+```json
+{
+  "name": "expect_file_artifact",
+  "parameters": {
+    "program_command": "python3 main.py",
+    "artifact_path": "report.txt",
+    "match_mode": "contains",
+    "expected_content": "PASSED"
+  },
+  "weight": 50
+}
+```
+
+---
+
 ### `dont_fail`
 
 Executes a program with a specific input and verifies it completes **without crashing**. The program's stdout is ignored — this test only validates that execution succeeds. Useful for testing error handling (e.g., sending invalid input).

--- a/sandbox_manager/models/sandbox_models.py
+++ b/sandbox_manager/models/sandbox_models.py
@@ -46,6 +46,16 @@ class CommandResponse:
         return self.stdout
 
 
+@dataclass
+class ExtractedFile:
+    """Result of extracting a single file from a sandbox container."""
+    path: str
+    content_bytes: bytes
+    size: int
+    content_text: str = ""
+    encoding: str = "utf-8"
+
+
 class HttpResponse:
     """Wrapper for HTTP responses from containerized applications."""
 

--- a/sandbox_manager/sandbox_container.py
+++ b/sandbox_manager/sandbox_container.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional
 from docker.models.containers import Container
 import requests
 from sandbox_manager.models.sandbox_models import Language, SandboxState, CommandResponse, HttpResponse, \
-    ResponseCategory
+    ResponseCategory, ExtractedFile
 from sandbox_manager.utils.classify_output import classify_output
 
 
@@ -295,6 +295,69 @@ class SandboxContainer:
             category=category
         )
 
+
+    def extract_file(self, path: str, max_bytes: int = 1_048_576) -> ExtractedFile:
+        """
+        Extract a single file from the container using Docker get_archive.
+
+        Args:
+            path: Absolute path inside the container (e.g. /app/output.txt).
+            max_bytes: Maximum allowed file size in bytes (default 1 MB).
+
+        Returns:
+            ExtractedFile with content and metadata.
+
+        Raises:
+            FileNotFoundError: If the file does not exist in the container.
+            ValueError: If the archive contains no regular file or file exceeds max_bytes.
+            RuntimeError: If the tar stream cannot be read.
+        """
+        import io
+        import tarfile
+
+        try:
+            bits, stat = self.container_ref.get_archive(path)
+        except Exception as e:
+            if "404" in str(e) or "Not Found" in str(e) or "No such" in str(e):
+                raise FileNotFoundError(f"File not found in container: {path}")
+            raise RuntimeError(f"Failed to retrieve archive from container: {e}")
+
+        try:
+            raw = b"".join(bits)
+            tar = tarfile.open(fileobj=io.BytesIO(raw))
+        except Exception as e:
+            raise RuntimeError(f"Failed to read tar stream: {e}")
+
+        # Find the first regular file in the archive
+        member = None
+        for m in tar.getmembers():
+            if m.isfile():
+                member = m
+                break
+
+        if member is None:
+            raise ValueError(f"No regular file found in archive for path: {path}")
+
+        if member.size > max_bytes:
+            raise ValueError(
+                f"File exceeds maximum size: {member.size} bytes > {max_bytes} bytes"
+            )
+
+        content_bytes = tar.extractfile(member).read()
+        try:
+            content_text = content_bytes.decode("utf-8")
+            encoding = "utf-8"
+        except UnicodeDecodeError:
+            content_text = content_bytes.decode("latin-1")
+            encoding = "latin-1"
+
+        return ExtractedFile(
+            path=path,
+            content_bytes=content_bytes,
+            size=len(content_bytes),
+            content_text=content_text,
+            encoding=encoding,
+        )
 
     def make_request(self,
                      request_method: str,

--- a/tests/unit/test_expect_file_artifact.py
+++ b/tests/unit/test_expect_file_artifact.py
@@ -1,0 +1,344 @@
+"""
+Unit tests for ExpectFileArtifactTest.
+
+Tests cover:
+- Exact match success
+- Contains match success
+- Regex match success
+- Content mismatch
+- Missing artifact file
+- Invalid regex pattern
+- Invalid artifact path (absolute, traversal)
+- Invalid match_mode
+- Execution failure (timeout, runtime error)
+- Normalization behavior
+- Registration in InputOutputTemplate
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from autograder.template_library.input_output import ExpectFileArtifactTest, InputOutputTemplate
+from sandbox_manager.models.sandbox_models import (
+    Language, CommandResponse, ResponseCategory, ExtractedFile,
+)
+
+
+def _make_sandbox(stdout="", stderr="", exit_code=0, category=ResponseCategory.SUCCESS):
+    """Return a mock sandbox whose run_commands returns the given CommandResponse."""
+    sandbox = MagicMock()
+    sandbox.run_commands.return_value = CommandResponse(
+        stdout=stdout, stderr=stderr, exit_code=exit_code,
+        execution_time=0.1, category=category,
+    )
+    sandbox.run_command.return_value = CommandResponse(
+        stdout=stdout, stderr=stderr, exit_code=exit_code,
+        execution_time=0.1, category=category,
+    )
+    return sandbox
+
+
+def _make_extracted(content: str, path="/app/output.txt"):
+    return ExtractedFile(
+        path=path,
+        content_bytes=content.encode("utf-8"),
+        size=len(content.encode("utf-8")),
+        content_text=content,
+        encoding="utf-8",
+    )
+
+
+class TestExpectFileArtifactExactMatch(unittest.TestCase):
+
+    def setUp(self):
+        self.test = ExpectFileArtifactTest()
+
+    def test_exact_match_success(self):
+        sandbox = _make_sandbox()
+        sandbox.extract_file.return_value = _make_extracted("hello world")
+
+        result = self.test.execute(
+            files=None, sandbox=sandbox,
+            program_command="python3 main.py",
+            artifact_path="output.txt",
+            expected_content="hello world",
+        )
+
+        self.assertEqual(result.score, 100.0)
+
+    def test_exact_match_with_normalization(self):
+        """Normalization strips trailing whitespace and normalizes line endings."""
+        sandbox = _make_sandbox()
+        sandbox.extract_file.return_value = _make_extracted("line1  \r\nline2  \n")
+
+        result = self.test.execute(
+            files=None, sandbox=sandbox,
+            program_command="python3 main.py",
+            artifact_path="output.txt",
+            expected_content="line1\nline2",
+        )
+
+        self.assertEqual(result.score, 100.0)
+
+    def test_exact_match_mismatch(self):
+        sandbox = _make_sandbox()
+        sandbox.extract_file.return_value = _make_extracted("wrong content")
+
+        result = self.test.execute(
+            files=None, sandbox=sandbox,
+            program_command="python3 main.py",
+            artifact_path="output.txt",
+            expected_content="expected content",
+        )
+
+        self.assertEqual(result.score, 0.0)
+        self.assertIn("wrong content", result.report)
+
+    def test_exact_match_no_normalization(self):
+        """When normalization is off, trailing whitespace matters."""
+        sandbox = _make_sandbox()
+        sandbox.extract_file.return_value = _make_extracted("hello ")
+
+        result = self.test.execute(
+            files=None, sandbox=sandbox,
+            program_command="python3 main.py",
+            artifact_path="output.txt",
+            expected_content="hello",
+            normalization=False,
+        )
+
+        self.assertEqual(result.score, 0.0)
+
+
+class TestExpectFileArtifactContainsMatch(unittest.TestCase):
+
+    def setUp(self):
+        self.test = ExpectFileArtifactTest()
+
+    def test_contains_match_success(self):
+        sandbox = _make_sandbox()
+        sandbox.extract_file.return_value = _make_extracted("result: PASSED with 100%")
+
+        result = self.test.execute(
+            files=None, sandbox=sandbox,
+            program_command="python3 main.py",
+            artifact_path="report.txt",
+            expected_content="PASSED",
+            match_mode="contains",
+        )
+
+        self.assertEqual(result.score, 100.0)
+
+    def test_contains_match_failure(self):
+        sandbox = _make_sandbox()
+        sandbox.extract_file.return_value = _make_extracted("result: FAILED")
+
+        result = self.test.execute(
+            files=None, sandbox=sandbox,
+            program_command="python3 main.py",
+            artifact_path="report.txt",
+            expected_content="PASSED",
+            match_mode="contains",
+        )
+
+        self.assertEqual(result.score, 0.0)
+
+
+class TestExpectFileArtifactRegexMatch(unittest.TestCase):
+
+    def setUp(self):
+        self.test = ExpectFileArtifactTest()
+
+    def test_regex_match_success(self):
+        sandbox = _make_sandbox()
+        sandbox.extract_file.return_value = _make_extracted("comparacoes: 42\ntempo: 0.003s")
+
+        result = self.test.execute(
+            files=None, sandbox=sandbox,
+            program_command="python3 main.py",
+            artifact_path="metrics.txt",
+            expected_content=r"comparacoes:\s*\d+",
+            match_mode="regex",
+        )
+
+        self.assertEqual(result.score, 100.0)
+
+    def test_regex_match_failure(self):
+        sandbox = _make_sandbox()
+        sandbox.extract_file.return_value = _make_extracted("no numbers here")
+
+        result = self.test.execute(
+            files=None, sandbox=sandbox,
+            program_command="python3 main.py",
+            artifact_path="metrics.txt",
+            expected_content=r"comparacoes:\s*\d+",
+            match_mode="regex",
+        )
+
+        self.assertEqual(result.score, 0.0)
+
+    def test_invalid_regex(self):
+        sandbox = _make_sandbox()
+
+        result = self.test.execute(
+            files=None, sandbox=sandbox,
+            program_command="python3 main.py",
+            artifact_path="output.txt",
+            expected_content="[invalid(regex",
+            match_mode="regex",
+        )
+
+        self.assertEqual(result.score, 0.0)
+        self.assertIn("regex", result.report.lower())
+
+
+class TestExpectFileArtifactErrors(unittest.TestCase):
+
+    def setUp(self):
+        self.test = ExpectFileArtifactTest()
+
+    def test_missing_artifact(self):
+        sandbox = _make_sandbox()
+        sandbox.extract_file.side_effect = FileNotFoundError("File not found")
+
+        result = self.test.execute(
+            files=None, sandbox=sandbox,
+            program_command="python3 main.py",
+            artifact_path="output.txt",
+            expected_content="anything",
+        )
+
+        self.assertEqual(result.score, 0.0)
+        self.assertIn("output.txt", result.report)
+
+    def test_extraction_error(self):
+        sandbox = _make_sandbox()
+        sandbox.extract_file.side_effect = RuntimeError("tar stream corrupt")
+
+        result = self.test.execute(
+            files=None, sandbox=sandbox,
+            program_command="python3 main.py",
+            artifact_path="output.txt",
+            expected_content="anything",
+        )
+
+        self.assertEqual(result.score, 0.0)
+        self.assertIn("tar stream corrupt", result.report)
+
+    def test_absolute_path_rejected(self):
+        sandbox = _make_sandbox()
+
+        result = self.test.execute(
+            files=None, sandbox=sandbox,
+            program_command="python3 main.py",
+            artifact_path="/etc/passwd",
+            expected_content="anything",
+        )
+
+        self.assertEqual(result.score, 0.0)
+        self.assertIn("Invalid", result.report)
+
+    def test_traversal_path_rejected(self):
+        sandbox = _make_sandbox()
+
+        result = self.test.execute(
+            files=None, sandbox=sandbox,
+            program_command="python3 main.py",
+            artifact_path="../secret.txt",
+            expected_content="anything",
+        )
+
+        self.assertEqual(result.score, 0.0)
+        self.assertIn("Invalid", result.report)
+
+    def test_invalid_match_mode(self):
+        sandbox = _make_sandbox()
+
+        result = self.test.execute(
+            files=None, sandbox=sandbox,
+            program_command="python3 main.py",
+            artifact_path="output.txt",
+            expected_content="anything",
+            match_mode="fuzzy",
+        )
+
+        self.assertEqual(result.score, 0.0)
+        self.assertIn("fuzzy", result.report)
+
+    def test_empty_artifact_path(self):
+        sandbox = _make_sandbox()
+
+        result = self.test.execute(
+            files=None, sandbox=sandbox,
+            program_command="python3 main.py",
+            artifact_path="",
+            expected_content="anything",
+        )
+
+        self.assertEqual(result.score, 0.0)
+
+
+class TestExpectFileArtifactExecutionFailures(unittest.TestCase):
+
+    def setUp(self):
+        self.test = ExpectFileArtifactTest()
+
+    def test_timeout(self):
+        sandbox = _make_sandbox(
+            stderr="Execution timed out after 30 seconds",
+            exit_code=124,
+            category=ResponseCategory.TIMEOUT,
+        )
+
+        result = self.test.execute(
+            files=None, sandbox=sandbox,
+            program_command="python3 main.py",
+            artifact_path="output.txt",
+            expected_content="anything",
+        )
+
+        self.assertEqual(result.score, 0.0)
+
+    def test_runtime_error(self):
+        sandbox = _make_sandbox(
+            stderr="ZeroDivisionError: division by zero",
+            exit_code=1,
+            category=ResponseCategory.RUNTIME_ERROR,
+        )
+
+        result = self.test.execute(
+            files=None, sandbox=sandbox,
+            program_command="python3 main.py",
+            artifact_path="output.txt",
+            expected_content="anything",
+        )
+
+        self.assertEqual(result.score, 0.0)
+
+
+class TestExpectFileArtifactMetadata(unittest.TestCase):
+
+    def test_name(self):
+        self.assertEqual(ExpectFileArtifactTest().name, "expect_file_artifact")
+
+    def test_description_not_empty(self):
+        self.assertTrue(len(ExpectFileArtifactTest().description) > 0)
+
+    def test_parameter_descriptions(self):
+        params = ExpectFileArtifactTest().parameter_description
+        names = [p.name for p in params]
+        self.assertIn("artifact_path", names)
+        self.assertIn("expected_content", names)
+        self.assertIn("match_mode", names)
+        self.assertIn("program_command", names)
+        self.assertIn("inputs", names)
+        self.assertIn("normalization", names)
+
+    def test_registered_in_template(self):
+        template = InputOutputTemplate()
+        test = template.get_test("expect_file_artifact")
+        self.assertIsInstance(test, ExpectFileArtifactTest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_extract_file.py
+++ b/tests/unit/test_extract_file.py
@@ -1,0 +1,141 @@
+"""
+Unit tests for SandboxContainer.extract_file.
+
+Tests cover:
+- Successful file extraction with UTF-8 content
+- Missing file (FileNotFoundError)
+- Oversized file (ValueError)
+- Invalid tar stream (RuntimeError)
+- Archive with no regular file (ValueError)
+"""
+
+import io
+import tarfile
+import unittest
+from unittest.mock import MagicMock
+
+from sandbox_manager.sandbox_container import SandboxContainer
+from sandbox_manager.models.sandbox_models import Language, ExtractedFile
+
+
+def _make_tar_bytes(filename: str, content: bytes) -> bytes:
+    """Build an in-memory tar archive containing a single file."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        info = tarfile.TarInfo(name=filename)
+        info.size = len(content)
+        tar.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+def _make_tar_directory_only(dirname: str) -> bytes:
+    """Build a tar archive containing only a directory entry (no regular file)."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        info = tarfile.TarInfo(name=dirname)
+        info.type = tarfile.DIRTYPE
+        tar.addfile(info)
+    return buf.getvalue()
+
+
+class TestExtractFile(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_container = MagicMock()
+        self.mock_container.id = "abc123def456"
+        self.sandbox = SandboxContainer(
+            language=Language.PYTHON,
+            container_ref=self.mock_container,
+        )
+
+    def test_success_utf8(self):
+        """Successful extraction of a UTF-8 text file."""
+        content = "comparacoes: 10\nmovimentacoes: 4\n"
+        tar_bytes = _make_tar_bytes("output.txt", content.encode("utf-8"))
+        stat = {"name": "output.txt", "size": len(content)}
+
+        self.mock_container.get_archive.return_value = (iter([tar_bytes]), stat)
+
+        result = self.sandbox.extract_file("/app/output.txt")
+
+        self.assertIsInstance(result, ExtractedFile)
+        self.assertEqual(result.path, "/app/output.txt")
+        self.assertEqual(result.content_text, content)
+        self.assertEqual(result.size, len(content.encode("utf-8")))
+        self.assertEqual(result.encoding, "utf-8")
+
+    def test_success_latin1_fallback(self):
+        """Falls back to latin-1 when content is not valid UTF-8."""
+        content_bytes = b"\xe9\xe8\xea"  # latin-1 chars, invalid UTF-8
+        tar_bytes = _make_tar_bytes("data.bin", content_bytes)
+        stat = {"name": "data.bin", "size": len(content_bytes)}
+
+        self.mock_container.get_archive.return_value = (iter([tar_bytes]), stat)
+
+        result = self.sandbox.extract_file("/app/data.bin")
+
+        self.assertEqual(result.encoding, "latin-1")
+        self.assertEqual(result.content_bytes, content_bytes)
+
+    def test_file_not_found(self):
+        """Raises FileNotFoundError when Docker returns 404."""
+        self.mock_container.get_archive.side_effect = Exception("404 Client Error: Not Found")
+
+        with self.assertRaises(FileNotFoundError) as ctx:
+            self.sandbox.extract_file("/app/missing.txt")
+
+        self.assertIn("missing.txt", str(ctx.exception))
+
+    def test_file_not_found_no_such(self):
+        """Raises FileNotFoundError when Docker says 'No such file'."""
+        self.mock_container.get_archive.side_effect = Exception("No such file or directory")
+
+        with self.assertRaises(FileNotFoundError):
+            self.sandbox.extract_file("/app/gone.txt")
+
+    def test_oversized_file(self):
+        """Raises ValueError when file exceeds max_bytes."""
+        big_content = b"x" * 200
+        tar_bytes = _make_tar_bytes("big.txt", big_content)
+        stat = {"name": "big.txt", "size": 200}
+
+        self.mock_container.get_archive.return_value = (iter([tar_bytes]), stat)
+
+        with self.assertRaises(ValueError) as ctx:
+            self.sandbox.extract_file("/app/big.txt", max_bytes=100)
+
+        self.assertIn("exceeds maximum size", str(ctx.exception))
+
+    def test_invalid_tar_stream(self):
+        """Raises RuntimeError when tar stream is corrupted."""
+        self.mock_container.get_archive.return_value = (iter([b"not-a-tar"]), {})
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self.sandbox.extract_file("/app/file.txt")
+
+        self.assertIn("Failed to read tar stream", str(ctx.exception))
+
+    def test_no_regular_file_in_archive(self):
+        """Raises ValueError when archive contains only a directory."""
+        tar_bytes = _make_tar_directory_only("somedir")
+        stat = {"name": "somedir", "size": 0}
+
+        self.mock_container.get_archive.return_value = (iter([tar_bytes]), stat)
+
+        with self.assertRaises(ValueError) as ctx:
+            self.sandbox.extract_file("/app/somedir")
+
+        self.assertIn("No regular file", str(ctx.exception))
+
+    def test_docker_api_generic_error(self):
+        """Raises RuntimeError for non-404 Docker errors."""
+        self.mock_container.get_archive.side_effect = Exception("Connection refused")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self.sandbox.extract_file("/app/file.txt")
+
+        self.assertIn("Failed to retrieve archive", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Context                                                                                                                                                                                                
                                                                                                                                                                                                            
  <!-- Why is this change needed? What problem or issue does it address? -->                                                                                                                                
                                                                                                                                                                                                            
  Some assignments require students to generate output files (e.g., `matricula_selecao.txt` with metrics like comparisons, movements, and execution time). The current execution model only validates       
  `stdout`/`stderr`/`exit_code` and has no first-class way to retrieve and grade file-based outputs from the sandbox container.                                                                             
                                                                                                                                                                                                            
  ## Solution                                                                                                                                                                                               
                                                                                                                                                                                                            
  <!-- What was changed and how does it solve the problem? -->                                                                                                                                              
                                                                                                                                                                                                            
  Implements `expect_file_artifact` as a **new test type** in the `input_output` template (not a mode of `expect_output`) for clear separation of concerns — `expect_output` validates the stdout contract, 
  `expect_file_artifact` validates the filesystem artifact contract.                                                                                                                                        
                                                                                                                                                                                                            
  ### Sandbox layer                                                                                                                                                                                         
  - Added `ExtractedFile` dataclass to `sandbox_manager/models/sandbox_models.py`                                                                                                                           
  - Added `SandboxContainer.extract_file(path, max_bytes)` using Docker `get_archive` API with in-memory tar decoding, 1MB size guardrail, and explicit error types (`FileNotFoundError`, `ValueError`,     
  `RuntimeError`)                                                                                                                                                                                           
                                                                                                                                                                                                            
  ### Test function                                                                                                                                                                                         
  - Added `ExpectFileArtifactTest` extending `BaseExecutionTest` in `input_output.py`                                                                                                                       
  - Supports three match modes: `exact` (default), `contains`, `regex`                                                                                                                                      
  - Configurable line-ending normalization (enabled by default)                                                                                                                                             
  - Validates artifact paths against traversal (`..`) and absolute paths                                                                                                                                    
  - Registered in `InputOutputTemplate.tests`                                                                                                                                                               
                                                                                                                                                                                                            
  ### Translations                                                                                                                                                                                          
  - Added `io.expect_file_artifact` keys in both `en.json` and `pt_br.json` (description, 6 params, 7 report messages)                                                                                      
                                                                                                                                                                                                            
  ### Documentation                                                                                                                                                                                         
  - Updated README template table with `expect_file_artifact` row                                                                                                                                           
  - Added full section in `docs/templates/input_output.md` with parameter table, scoring, error handling, path conventions, and examples for all three match modes                                          
                                                                                                                                                                                                            
  ### Tests                                                                                                                                                                                                 
  - 8 unit tests for `SandboxContainer.extract_file` (success paths, missing file, oversized, invalid tar, no regular file, Docker errors)                                                                  
  - 21 unit tests for `ExpectFileArtifactTest` (all match modes, normalization, mismatch, missing artifact, extraction errors, path validation, invalid regex, execution failures, metadata, template       
  registration)                                                                                                                                                                                             
                                                                                                                                                                                                            
  ## Further clarifications                                                                                                                                                                                 
                                                                                                                                                                                                            
  <!-- Any tradeoffs, limitations, follow-up work, or reviewer notes. -->                                                                                                                                   
                                                                                                                                                                                                            
  - **Bugfix included:** `BaseExecutionTest.check_for_base_errors` had a pre-existing `NameError` referencing `kwargs` without receiving it as a parameter. Fixed by adding `**kwargs` and updating all     
  three call sites to pass `locale`. This was necessary for the execution failure error paths to work correctly.                                                                                            
  - **MVP scope:** Single-file extraction only. Multi-file archive extraction in one call is out of scope.                                                                                                  
  - **No API contract changes:** This is a new test function available through existing grading config schemas — no endpoint, DTO, or request/response changes.                                             
                                                                                                                                                                                                            
  ## Related issues                                                                                                                                                                                         
                                                                                                                                                                                                            
  <!-- Example: Closes #123 -->                                                                                                                                                                             
                                                                                                                                                                                                            
  Closes #282                                                                                                                                                                                               
                                                                                                                                                                                                            
  Related:                                                                                                                                                                                                  
  - Static Asset Placement baseline: #280                                                                                                                                                                   
  - S3 provider for assets: #281                                                                                                                                                                            
                                                                                                                                                                                                            
  ## Checklist                                                                                                                                                                                              
                                                                                                                                                                                                            
  - [x] I linked the related issue(s) and explained the motivation.                                                                                                                                         
  - [x] I kept this PR focused and scoped to a single concern.                                                                                                                                              
  - [x] I added or updated tests for changed behavior (or explained why not needed).                                                                                                                        
  - [x] I ran the relevant tests locally.                                                                                                                                                                   
  - [x] I updated documentation when needed (README/docs/API examples).                                                                                                                                     
  - [ ] This PR introduces API contract changes (request/response/endpoint/DTO).                                                                                                                            
  - [ ] If API changed, I documented compatibility or migration notes.                                                                                                                                      
  - [ ] This PR includes breaking changes.                                                                                                                                                                  
  - [ ] If breaking, I clearly described impact and migration steps.  