### PR TITLE
fixing grading step

### DIFF
--- a/autograder/models/config/category.py
+++ b/autograder/models/config/category.py
@@ -20,7 +20,7 @@ class CategoryConfig(BaseModel):
         description="Weight of the subject when it is a heterogeneous tree",
     )
 
-    model_config = {"extra": "forbid"}
+    model_config = {"extra": "allow"}
 
     @model_validator(mode="after")
     def check_subjects_and_tests(self) -> "CategoryConfig":

--- a/autograder/models/config/criteria.py
+++ b/autograder/models/config/criteria.py
@@ -14,7 +14,7 @@ class CriteriaConfig(BaseModel):
     bonus: Optional[CategoryConfig] = Field(None, description="Bonus points criteria")
     penalty: Optional[CategoryConfig] = Field(None, description="Penalty criteria")
 
-    model_config = {"extra": "forbid"}
+    model_config = {"extra": "allow"}
 
     @classmethod
     def from_dict(cls, data: dict) -> "CriteriaConfig":

--- a/autograder/models/config/subject.py
+++ b/autograder/models/config/subject.py
@@ -21,7 +21,7 @@ class SubjectConfig(BaseModel):
         description="Weight of the subject when it is a heterogeneous tree",
     )
 
-    model_config = {"extra": "forbid"}
+    model_config = {"extra": "allow"}
 
     @model_validator(mode="after")
     def check_subjects_and_tests(self) -> "SubjectConfig":

--- a/autograder/models/config/test.py
+++ b/autograder/models/config/test.py
@@ -8,13 +8,16 @@ class ParameterConfig(BaseModel):
     name: str = Field(..., description="Parameter name")
     value: Any = Field(..., description="Parameter value")
 
-    model_config = {"extra": "forbid"}
+    model_config = {"extra": "allow"}
 
 
 class TestConfig(BaseModel):
     """Configuration for a single test execution."""
 
-    name: str = Field(..., description="Name of the test function in the template")
+    name: str = Field(..., description="Display name of the test")
+    type: Optional[str] = Field(
+        None, description="Technical type of the test (e.g., expect_output)"
+    )
     file: Optional[str] = Field(
         None, description="Target file for the test (if applicable)"
     )
@@ -24,7 +27,7 @@ class TestConfig(BaseModel):
     weight: Optional[float] = Field(100.0, ge=0, description="Weight of this test")
 
 
-    model_config = {"extra": "forbid"}
+    model_config = {"extra": "allow"}
 
 
     def get_args_list(self) -> List[Any]:
@@ -35,6 +38,11 @@ class TestConfig(BaseModel):
 
     def get_kwargs_dict(self) -> Dict[str, Any]:
         """Convert named parameters to keyword arguments dictionary."""
-        if not self.parameters:
-            return {}
-        return {param.name: param.value for param in self.parameters}
+        kwargs = {}
+        if self.parameters:
+            kwargs.update({param.name: param.value for param in self.parameters})
+
+        if self.model_extra:
+            kwargs.update(self.model_extra)
+
+        return kwargs

--- a/autograder/services/criteria_tree_service.py
+++ b/autograder/services/criteria_tree_service.py
@@ -92,9 +92,11 @@ class CriteriaTreeService:
             return None
 
     def __parse_test(self, config: TestConfig) -> TestNode:
-        test_function = self.__find_test_function(config.name)
+        # Use technical 'type' for function lookup, falling back to 'name' for legacy support
+        function_name = config.type or config.name
+        test_function = self.__find_test_function(function_name)
         if not test_function:
-            raise ValueError(f"Couldn't find test {config.name}")
+            raise ValueError(f"Couldn't find test function '{function_name}'")
 
         file_target = [config.file] if config.file else None
 

--- a/tests/unit/test_config_models.py
+++ b/tests/unit/test_config_models.py
@@ -44,10 +44,11 @@ class TestParameterConfig:
         assert param.value == 1
         assert isinstance(param.value, int)
 
-    def test_parameter_config_forbid_extra(self):
-        """Test that extra fields are forbidden"""
-        with pytest.raises(ValueError):
-            ParameterConfig(name="tag", value="body", extra_field="not allowed")
+    def test_parameter_config_allow_extra(self):
+        """Test that extra fields are allowed"""
+        param = ParameterConfig(name="tag", value="body", extra_field="allowed")
+        assert param.name == "tag"
+        assert param.extra_field == "allowed"
 
 
 class TestTestConfig:
@@ -471,24 +472,25 @@ class TestSchemaIntegration:
                 tests=[TestConfig(file="test.html", name="test")]
             )
 
-    def test_extra_fields_forbidden(self):
-        """Test that extra fields are forbidden at all levels"""
+    def test_extra_fields_allowed(self):
+        """Test that extra fields are allowed at all levels"""
         # Test at criteria level
-        with pytest.raises(ValueError):
-            CriteriaConfig(
-                test_library="web_dev",
-                base=CategoryConfig(
-                    weight=100,
-                    subjects=[
-                        SubjectConfig(
-                            subject_name="html",
-                            weight=60,
-                            tests=[TestConfig(file="index.html", name="has_tag")]
-                        )
-                    ]
-                ),
-                extra_field="not allowed"
-            )
+        criteria = CriteriaConfig(
+            test_library="web_dev",
+            base=CategoryConfig(
+                weight=100,
+                subjects=[
+                    SubjectConfig(
+                        subject_name="html",
+                        weight=60,
+                        tests=[TestConfig(file="index.html", name="has_tag", extra_field="allowed")]
+                    )
+                ]
+            ),
+            extra_field="allowed"
+        )
+        assert criteria.extra_field == "allowed"
+        assert criteria.base.subjects[0].tests[0].extra_field == "allowed"
 
 
 class TestWeightCalculations:


### PR DESCRIPTION
`model_config` was forbid across autograder models, leading to a error during the grading step.
This pull requests fix this issue, updating `model_config`  to allow. 
