### PR TITLE
283 external mode web api contract config fetch external result ingestion

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -16,23 +16,64 @@ API documentation (Swagger UI) available at: `http://localhost:8000/docs`
 
 ---
 
+## Authentication
+
+Most endpoints are public and require no authentication. Two endpoints designed for machine-to-machine integration (GitHub Action external mode) are protected with a Bearer token.
+
+### Protected Endpoints
+
+| Endpoint | Method |
+|----------|--------|
+| `/api/v1/configs/id/{config_id}` | GET |
+| `/api/v1/submissions/external-results` | POST |
+
+### Setup
+
+Set the `AUTOGRADER_INTEGRATION_TOKEN` environment variable on the server:
+
+```bash
+# Generate a strong random token
+export AUTOGRADER_INTEGRATION_TOKEN=$(openssl rand -hex 32)
+```
+
+When the variable is **not set or empty**, the server will reject all requests to protected endpoints with `401 Unauthorized`. The token **must** be configured before using integration endpoints.
+
+### Usage
+
+Include the token in the `Authorization` header:
+
+```bash
+curl -H "Authorization: Bearer $AUTOGRADER_INTEGRATION_TOKEN" \
+     http://localhost:8000/api/v1/configs/id/1
+```
+
+### Error Responses
+
+| Status | Condition |
+|--------|-----------|
+| `401 Unauthorized` | Missing or invalid token |
+
+---
+
 ## Endpoints Overview
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `POST` | `/api/v1/configs` | Create a grading configuration |
-| `GET` | `/api/v1/configs` | List all grading configurations |
-| `GET` | `/api/v1/configs/{external_assignment_id}` | Get configuration by assignment ID |
-| `PUT` | `/api/v1/configs/{config_id}` | Update a grading configuration |
-| `PUT` | `/api/v1/configs/external/{external_assignment_id}` | Update a grading configuration by external assignment ID |
-| `POST` | `/api/v1/submissions` | Submit code for grading |
-| `GET` | `/api/v1/submissions/{submission_id}` | Get submission details and results |
-| `GET` | `/api/v1/submissions/user/{external_user_id}` | List submissions by user |
-| `POST` | `/api/v1/execute` | Execute code without grading (DCE) |
-| `GET` | `/api/v1/templates` | List available grading templates |
-| `GET` | `/api/v1/templates/{template_name}` | Get template details |
-| `GET` | `/api/v1/health` | Health check |
-| `GET` | `/api/v1/ready` | Readiness check |
+| Method | Endpoint | Description | Auth |
+|--------|----------|-------------|------|
+| `POST` | `/api/v1/configs` | Create a grading configuration | |
+| `GET` | `/api/v1/configs` | List all grading configurations | |
+| `GET` | `/api/v1/configs/id/{config_id}` | Get configuration by internal ID | ✓ |
+| `GET` | `/api/v1/configs/{external_assignment_id}` | Get configuration by assignment ID | |
+| `PUT` | `/api/v1/configs/{config_id}` | Update a grading configuration | |
+| `PUT` | `/api/v1/configs/external/{external_assignment_id}` | Update a grading configuration by external assignment ID | |
+| `POST` | `/api/v1/submissions` | Submit code for grading | |
+| `GET` | `/api/v1/submissions/{submission_id}` | Get submission details and results | |
+| `GET` | `/api/v1/submissions/user/{external_user_id}` | List submissions by user | |
+| `POST` | `/api/v1/submissions/external-results` | Ingest externally computed grading results | ✓ |
+| `POST` | `/api/v1/execute` | Execute code without grading (DCE) | |
+| `GET` | `/api/v1/templates` | List available grading templates | |
+| `GET` | `/api/v1/templates/{template_name}` | Get template details | |
+| `GET` | `/api/v1/health` | Health check | |
+| `GET` | `/api/v1/ready` | Readiness check | |
 
 ---
 
@@ -157,6 +198,37 @@ GET /api/v1/configs?limit=100&offset=0
   }
 ]
 ```
+
+### Get Grading Configuration by Internal ID
+
+```http
+GET /api/v1/configs/id/{config_id}
+Authorization: Bearer <token>
+```
+
+>  **Protected** — requires a valid integration token (see [Authentication](#authentication)).
+
+Fetch a grading configuration using its internal database ID. This is used by external/private mode (e.g. GitHub Action) when only the `grading_config_id` is known.
+
+**Response (200 OK):**
+```json
+{
+  "id": 1,
+  "external_assignment_id": "assignment-42",
+  "template_name": "input_output",
+  "criteria_config": { ... },
+  "languages": ["python", "java"],
+  "setup_config": { ... },
+  "include_feedback": true,
+  "feedback_config": { ... },
+  "version": 1,
+  "created_at": "2026-02-16T10:00:00Z",
+  "updated_at": "2026-02-16T10:00:00Z",
+  "is_active": true
+}
+```
+
+**Error (404):** Configuration not found.
 
 ### Get Grading Configuration
 
@@ -522,6 +594,77 @@ GET /api/v1/submissions/user/{external_user_id}?limit=100&offset=0
   }
 ]
 ```
+
+### Ingest External Grading Results
+
+```http
+POST /api/v1/submissions/external-results
+Content-Type: application/json
+Authorization: Bearer <token>
+```
+
+> 🔒 **Protected** — requires a valid integration token (see [Authentication](#authentication)).
+
+Persist grading results computed outside the cloud instance (e.g. GitHub Action running in external/private mode). Creates both a `submission` and a `submission_result` row, making the result visible through the standard submission retrieval endpoints.
+
+**Request Body:**
+```json
+{
+  "grading_config_id": 1,
+  "external_user_id": "user_001",
+  "username": "student123",
+  "language": "python",
+  "status": "completed",
+  "final_score": 85.5,
+  "feedback": "## Grade: 85.5/100\n...",
+  "result_tree": { ... },
+  "focus": { ... },
+  "pipeline_execution": { ... },
+  "execution_time_ms": 4521,
+  "error_message": null,
+  "submission_metadata": {
+    "repo": "org/repo",
+    "run_id": "123"
+  }
+}
+```
+
+**Request Fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `grading_config_id` | int | ✓ | Internal grading configuration ID |
+| `external_user_id` | string | ✓ | External user ID from your platform |
+| `username` | string | ✓ | Username of the submitter |
+| `language` | string | ✓ | Language used for grading (must be supported by the config) |
+| `status` | string | ✓ | `completed` or `failed` |
+| `final_score` | float | ✓ | Final grading score (≥ 0) |
+| `feedback` | string | ✗ | Generated feedback text |
+| `result_tree` | object | ✗ | Scored result tree |
+| `focus` | object | ✗ | Failed tests sorted by impact |
+| `pipeline_execution` | object | ✗ | Pipeline step execution details |
+| `execution_time_ms` | int | ✓ | Total execution time in milliseconds (≥ 0) |
+| `error_message` | string | ✗ | Error message for failed runs |
+| `submission_metadata` | object | ✗ | Repository/run metadata |
+
+**Response (200 OK):**
+```json
+{
+  "submission_id": 5,
+  "grading_config_id": 1,
+  "external_user_id": "user_001",
+  "username": "student123",
+  "status": "completed",
+  "final_score": 85.5,
+  "graded_at": "2026-02-16T10:05:03Z",
+  "execution_time_ms": 4521
+}
+```
+
+**Errors:**
+- `404`: Grading configuration not found
+- `400`: Language not supported for this configuration
+- `422`: Validation error (invalid status, negative score, missing required fields)
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -36,7 +36,7 @@ Set the `AUTOGRADER_INTEGRATION_TOKEN` environment variable on the server:
 export AUTOGRADER_INTEGRATION_TOKEN=$(openssl rand -hex 32)
 ```
 
-When the variable is **not set or empty**, the server will reject all requests to protected endpoints with `401 Unauthorized`. The token **must** be configured before using integration endpoints.
+When the variable is **not set or empty**, the server will fail to start the integration auth configuration and protected endpoints will return `503 Service Unavailable`. The token **must** be configured and non-empty before using integration endpoints.
 
 ### Usage
 

--- a/tests/web/test_external_results.py
+++ b/tests/web/test_external_results.py
@@ -2,7 +2,7 @@
 
 import pytest
 from httpx import AsyncClient, ASGITransport
-from unittest.mock import Mock, patch, AsyncMock
+from unittest.mock import Mock, patch
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
 from sqlalchemy.pool import StaticPool
 

--- a/tests/web/test_external_results.py
+++ b/tests/web/test_external_results.py
@@ -1,0 +1,381 @@
+"""Tests for config fetch by ID and external result ingestion endpoints."""
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+from unittest.mock import Mock, patch, AsyncMock
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+from sqlalchemy.pool import StaticPool
+
+import web.config.auth as auth_module
+from web.config.auth import IntegrationAuthConfig
+from web.database.base import Base
+from web.database import session
+
+TEST_TOKEN = "test-external-results-token"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def mock_external_services():
+    """Mock external services for all tests."""
+    with patch("web.core.lifespan.initialize_sandbox_manager"), \
+         patch("web.core.lifespan.TemplateLibraryService") as mock_template, \
+         patch("web.core.lifespan.SandboxPoolConfig.load_from_yaml", return_value=[]):
+
+        mock_service = Mock()
+        mock_service.get_all_templates_info = Mock(return_value=[
+            {"name": "input_output", "description": "I/O testing"}
+        ])
+        mock_service.get_template_info = Mock(return_value={
+            "name": "input_output",
+            "description": "I/O testing",
+            "supported_languages": ["python"],
+        })
+        mock_template.get_instance.return_value = mock_service
+        yield
+
+
+from web.main import app
+
+
+@pytest.fixture(autouse=True)
+def _set_integration_token():
+    """Ensure the integration token is set for every test."""
+    cfg = IntegrationAuthConfig.__new__(IntegrationAuthConfig)
+    cfg.token = TEST_TOKEN
+    auth_module.integration_auth_config = cfg
+    yield
+    auth_module.integration_auth_config = cfg
+
+
+def _auth_header() -> dict:
+    return {"Authorization": f"Bearer {TEST_TOKEN}"}
+
+
+@pytest.fixture
+async def test_db():
+    """Create a fresh test database for each test."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    old_session_maker = session.AsyncSessionLocal
+    old_engine = getattr(session, "engine", None)
+    session.AsyncSessionLocal = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    session.engine = engine
+
+    yield engine
+
+    session.AsyncSessionLocal = old_session_maker
+    if old_engine is not None:
+        session.engine = old_engine
+    await engine.dispose()
+
+
+@pytest.fixture
+async def client(test_db):
+    """Create test client."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as ac:
+        yield ac
+
+
+async def _create_config(client, external_id="ext-assign-1"):
+    """Helper to create a grading config and return its internal ID."""
+    config_data = {
+        "external_assignment_id": external_id,
+        "template_name": "input_output",
+        "languages": ["python"],
+        "criteria_config": {"base": {"tests": ["test_hello"]}},
+        "setup_config": {"main_file": "main.py"},
+        "feedback_config": {"show_score": True},
+        "include_feedback": True,
+    }
+    resp = await client.post("/api/v1/configs", json=config_data)
+    assert resp.status_code == 200
+    return resp.json()
+
+
+# ── GET /api/v1/configs/id/{config_id} ─────────────────────────
+
+
+class TestGetConfigById:
+    """Tests for fetching grading config by internal ID."""
+
+    @pytest.mark.asyncio
+    async def test_get_config_by_id_success(self, client):
+        """Fetch an existing config by its internal ID."""
+        created = await _create_config(client, "id-lookup-1")
+        config_id = created["id"]
+
+        response = await client.get(f"/api/v1/configs/id/{config_id}", headers=_auth_header())
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == config_id
+        assert data["external_assignment_id"] == "id-lookup-1"
+        assert data["template_name"] == "input_output"
+        assert data["languages"] == ["python"]
+        assert data["criteria_config"] == {"base": {"tests": ["test_hello"]}}
+        assert data["setup_config"] == {"main_file": "main.py"}
+        assert data["feedback_config"] == {"show_score": True}
+        assert data["include_feedback"] is True
+        assert data["version"] is not None
+        assert data["is_active"] is True
+
+    @pytest.mark.asyncio
+    async def test_get_config_by_id_not_found(self, client):
+        """Return 404 for non-existent config ID."""
+        response = await client.get("/api/v1/configs/id/99999", headers=_auth_header())
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_get_config_by_id_returns_all_fields(self, client):
+        """Response includes all fields required by build_pipeline."""
+        created = await _create_config(client, "id-lookup-fields")
+        config_id = created["id"]
+
+        response = await client.get(f"/api/v1/configs/id/{config_id}", headers=_auth_header())
+        data = response.json()
+
+        required_keys = [
+            "template_name", "criteria_config", "setup_config",
+            "feedback_config", "include_feedback", "languages",
+            "external_assignment_id", "version", "is_active",
+        ]
+        for key in required_keys:
+            assert key in data, f"Missing key: {key}"
+
+
+# ── POST /api/v1/submissions/external-results ──────────────────
+
+
+class TestExternalResultIngestion:
+    """Tests for external grading result ingestion."""
+
+    @pytest.mark.asyncio
+    async def test_ingest_completed_result(self, client):
+        """Successfully ingest a completed external result."""
+        created = await _create_config(client, "ext-result-1")
+        config_id = created["id"]
+
+        payload = {
+            "grading_config_id": config_id,
+            "external_user_id": "student-42",
+            "username": "alice",
+            "language": "python",
+            "status": "completed",
+            "final_score": 85.5,
+            "feedback": "Good job!",
+            "result_tree": {"root": {"score": 85.5}},
+            "focus": {"failed": []},
+            "pipeline_execution": {"steps": ["grade"]},
+            "execution_time_ms": 1234,
+            "submission_metadata": {"repo": "org/repo", "run_id": "123"},
+        }
+
+        response = await client.post("/api/v1/submissions/external-results", json=payload, headers=_auth_header())
+        assert response.status_code == 200
+        data = response.json()
+        assert data["submission_id"] is not None
+        assert data["grading_config_id"] == config_id
+        assert data["external_user_id"] == "student-42"
+        assert data["username"] == "alice"
+        assert data["status"] == "completed"
+        assert data["final_score"] == 85.5
+        assert data["graded_at"] is not None
+        assert data["execution_time_ms"] == 1234
+
+    @pytest.mark.asyncio
+    async def test_ingest_failed_result(self, client):
+        """Successfully ingest a failed external result."""
+        created = await _create_config(client, "ext-result-fail")
+        config_id = created["id"]
+
+        payload = {
+            "grading_config_id": config_id,
+            "external_user_id": "student-43",
+            "username": "bob",
+            "language": "python",
+            "status": "failed",
+            "final_score": 0.0,
+            "execution_time_ms": 500,
+            "error_message": "Compilation error",
+        }
+
+        response = await client.post("/api/v1/submissions/external-results", json=payload, headers=_auth_header())
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "failed"
+        assert data["final_score"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_ingest_result_visible_via_submission_detail(self, client):
+        """Ingested result is visible through the existing submission detail endpoint."""
+        created = await _create_config(client, "ext-result-visible")
+        config_id = created["id"]
+
+        payload = {
+            "grading_config_id": config_id,
+            "external_user_id": "student-44",
+            "username": "carol",
+            "language": "python",
+            "status": "completed",
+            "final_score": 92.0,
+            "feedback": "Excellent",
+            "result_tree": {"root": {"score": 92.0}},
+            "focus": {"top": "test_1"},
+            "execution_time_ms": 800,
+        }
+
+        ingest_resp = await client.post("/api/v1/submissions/external-results", json=payload, headers=_auth_header())
+        assert ingest_resp.status_code == 200
+        submission_id = ingest_resp.json()["submission_id"]
+
+        # Retrieve via existing detail endpoint
+        detail_resp = await client.get(f"/api/v1/submissions/{submission_id}")
+        assert detail_resp.status_code == 200
+        detail = detail_resp.json()
+        assert detail["final_score"] == 92.0
+        assert detail["feedback"] == "Excellent"
+        assert detail["result_tree"] == {"root": {"score": 92.0}}
+        assert detail["focus"] == {"top": "test_1"}
+        assert detail["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_ingest_result_visible_via_user_submissions(self, client):
+        """Ingested result is visible through the user submissions list endpoint."""
+        created = await _create_config(client, "ext-result-user")
+        config_id = created["id"]
+
+        payload = {
+            "grading_config_id": config_id,
+            "external_user_id": "student-unique-45",
+            "username": "dave",
+            "language": "python",
+            "status": "completed",
+            "final_score": 77.0,
+            "execution_time_ms": 600,
+        }
+
+        await client.post("/api/v1/submissions/external-results", json=payload, headers=_auth_header())
+
+        user_resp = await client.get("/api/v1/submissions/user/student-unique-45")
+        assert user_resp.status_code == 200
+        submissions = user_resp.json()
+        assert len(submissions) >= 1
+        assert submissions[0]["external_user_id"] == "student-unique-45"
+        assert submissions[0]["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_ingest_result_config_not_found(self, client):
+        """Return 404 when grading config does not exist."""
+        payload = {
+            "grading_config_id": 99999,
+            "external_user_id": "student-50",
+            "username": "eve",
+            "language": "python",
+            "status": "completed",
+            "final_score": 50.0,
+            "execution_time_ms": 100,
+        }
+
+        response = await client.post("/api/v1/submissions/external-results", json=payload, headers=_auth_header())
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_ingest_result_unsupported_language(self, client):
+        """Return 400 when language is not supported by the config."""
+        created = await _create_config(client, "ext-result-badlang")
+        config_id = created["id"]
+
+        payload = {
+            "grading_config_id": config_id,
+            "external_user_id": "student-51",
+            "username": "frank",
+            "language": "java",  # config only supports python
+            "status": "completed",
+            "final_score": 50.0,
+            "execution_time_ms": 100,
+        }
+
+        response = await client.post("/api/v1/submissions/external-results", json=payload, headers=_auth_header())
+        assert response.status_code == 400
+        assert "not supported" in response.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_ingest_result_invalid_language(self, client):
+        """Return 422 for a completely invalid language value."""
+        created = await _create_config(client, "ext-result-invalidlang")
+        config_id = created["id"]
+
+        payload = {
+            "grading_config_id": config_id,
+            "external_user_id": "student-52",
+            "username": "grace",
+            "language": "brainfuck",
+            "status": "completed",
+            "final_score": 50.0,
+            "execution_time_ms": 100,
+        }
+
+        response = await client.post("/api/v1/submissions/external-results", json=payload, headers=_auth_header())
+        assert response.status_code == 422  # Pydantic validation error
+
+    @pytest.mark.asyncio
+    async def test_ingest_result_invalid_status(self, client):
+        """Return 422 for an invalid status value."""
+        created = await _create_config(client, "ext-result-badstatus")
+        config_id = created["id"]
+
+        payload = {
+            "grading_config_id": config_id,
+            "external_user_id": "student-53",
+            "username": "heidi",
+            "language": "python",
+            "status": "pending",  # not valid for external results
+            "final_score": 50.0,
+            "execution_time_ms": 100,
+        }
+
+        response = await client.post("/api/v1/submissions/external-results", json=payload, headers=_auth_header())
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_ingest_result_negative_score(self, client):
+        """Return 422 for a negative final score."""
+        created = await _create_config(client, "ext-result-negscore")
+        config_id = created["id"]
+
+        payload = {
+            "grading_config_id": config_id,
+            "external_user_id": "student-54",
+            "username": "ivan",
+            "language": "python",
+            "status": "completed",
+            "final_score": -10.0,
+            "execution_time_ms": 100,
+        }
+
+        response = await client.post("/api/v1/submissions/external-results", json=payload, headers=_auth_header())
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_ingest_result_missing_required_fields(self, client):
+        """Return 422 when required fields are missing."""
+        payload = {
+            "grading_config_id": 1,
+            "external_user_id": "student-55",
+            # missing username, language, status, final_score, execution_time_ms
+        }
+
+        response = await client.post("/api/v1/submissions/external-results", json=payload, headers=_auth_header())
+        assert response.status_code == 422

--- a/tests/web/test_integration_auth.py
+++ b/tests/web/test_integration_auth.py
@@ -41,11 +41,12 @@ from web.main import app
 @pytest.fixture(autouse=True)
 def _set_integration_token():
     """Ensure the integration token is set for every test."""
+    old_integration_auth_config = getattr(auth_module, "integration_auth_config", None)
     cfg = IntegrationAuthConfig.__new__(IntegrationAuthConfig)
     cfg.token = TEST_TOKEN
     auth_module.integration_auth_config = cfg
     yield
-    auth_module.integration_auth_config = cfg
+    auth_module.integration_auth_config = old_integration_auth_config
 
 
 @pytest.fixture

--- a/tests/web/test_integration_auth.py
+++ b/tests/web/test_integration_auth.py
@@ -1,0 +1,257 @@
+"""Tests for M2M integration token authentication on protected endpoints."""
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+from unittest.mock import Mock, patch
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+from sqlalchemy.pool import StaticPool
+
+import web.config.auth as auth_module
+from web.config.auth import IntegrationAuthConfig
+from web.database.base import Base
+from web.database import session
+
+
+TEST_TOKEN = "test-integration-secret-token-abc123"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def mock_external_services():
+    """Mock external services for all tests."""
+    with patch("web.core.lifespan.initialize_sandbox_manager"), \
+         patch("web.core.lifespan.TemplateLibraryService") as mock_template, \
+         patch("web.core.lifespan.SandboxPoolConfig.load_from_yaml", return_value=[]):
+
+        mock_service = Mock()
+        mock_service.get_all_templates_info = Mock(return_value=[
+            {"name": "input_output", "description": "I/O testing"}
+        ])
+        mock_service.get_template_info = Mock(return_value={
+            "name": "input_output",
+            "description": "I/O testing",
+            "supported_languages": ["python"],
+        })
+        mock_template.get_instance.return_value = mock_service
+        yield
+
+
+from web.main import app
+
+
+@pytest.fixture(autouse=True)
+def _set_integration_token():
+    """Ensure the integration token is set for every test."""
+    cfg = IntegrationAuthConfig.__new__(IntegrationAuthConfig)
+    cfg.token = TEST_TOKEN
+    auth_module.integration_auth_config = cfg
+    yield
+    auth_module.integration_auth_config = cfg
+
+
+@pytest.fixture
+async def test_db():
+    """Create a fresh test database for each test."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    old_session_maker = session.AsyncSessionLocal
+    old_engine = getattr(session, "engine", None)
+    session.AsyncSessionLocal = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    session.engine = engine
+
+    yield engine
+
+    session.AsyncSessionLocal = old_session_maker
+    if old_engine is not None:
+        session.engine = old_engine
+    await engine.dispose()
+
+
+@pytest.fixture
+async def client(test_db):
+    """Create test client."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as ac:
+        yield ac
+
+
+def _auth_header(token: str = TEST_TOKEN) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _create_config(client):
+    """Helper — config creation is public, no auth needed."""
+    import uuid
+    config_data = {
+        "external_assignment_id": f"auth-test-{uuid.uuid4().hex[:8]}",
+        "template_name": "input_output",
+        "languages": ["python"],
+        "criteria_config": {"base": {"tests": ["test_hello"]}},
+    }
+    resp = await client.post("/api/v1/configs", json=config_data)
+    assert resp.status_code == 200
+    return resp.json()
+
+
+# ── Missing token → 401 ────────────────────────────────────────
+
+
+class TestAuthMissingToken:
+    """Requests without a token get 401."""
+
+    @pytest.mark.asyncio
+    async def test_config_by_id_no_token_401(self, client):
+        resp = await client.get("/api/v1/configs/id/1")
+        assert resp.status_code == 401
+        assert "missing" in resp.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_external_results_no_token_401(self, client):
+        payload = {
+            "grading_config_id": 1,
+            "external_user_id": "u1",
+            "username": "student",
+            "language": "python",
+            "status": "completed",
+            "final_score": 100.0,
+            "execution_time_ms": 100,
+        }
+        resp = await client.post("/api/v1/submissions/external-results", json=payload)
+        assert resp.status_code == 401
+
+
+# ── Wrong token → 401 ──────────────────────────────────────────
+
+
+class TestAuthInvalidToken:
+    """Requests with a wrong token get 401."""
+
+    @pytest.mark.asyncio
+    async def test_config_by_id_wrong_token_401(self, client):
+        resp = await client.get(
+            "/api/v1/configs/id/1",
+            headers=_auth_header("wrong-token"),
+        )
+        assert resp.status_code == 401
+        assert "invalid" in resp.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_external_results_wrong_token_401(self, client):
+        payload = {
+            "grading_config_id": 1,
+            "external_user_id": "u1",
+            "username": "student",
+            "language": "python",
+            "status": "completed",
+            "final_score": 100.0,
+            "execution_time_ms": 100,
+        }
+        resp = await client.post(
+            "/api/v1/submissions/external-results",
+            json=payload,
+            headers=_auth_header("wrong-token"),
+        )
+        assert resp.status_code == 401
+
+
+# ── Valid token → success ───────────────────────────────────────
+
+
+class TestAuthValidToken:
+    """Valid token grants access to protected endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_config_by_id_valid_token(self, client):
+        created = await _create_config(client)
+        resp = await client.get(
+            f"/api/v1/configs/id/{created['id']}",
+            headers=_auth_header(),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["id"] == created["id"]
+
+    @pytest.mark.asyncio
+    async def test_external_results_valid_token(self, client):
+        created = await _create_config(client)
+        payload = {
+            "grading_config_id": created["id"],
+            "external_user_id": "u-auth",
+            "username": "student_auth",
+            "language": "python",
+            "status": "completed",
+            "final_score": 95.0,
+            "execution_time_ms": 200,
+        }
+        resp = await client.post(
+            "/api/v1/submissions/external-results",
+            json=payload,
+            headers=_auth_header(),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["final_score"] == 95.0
+
+    @pytest.mark.asyncio
+    async def test_config_by_id_not_found_still_404(self, client):
+        """Auth passes but resource doesn't exist → 404, not 401."""
+        resp = await client.get(
+            "/api/v1/configs/id/99999",
+            headers=_auth_header(),
+        )
+        assert resp.status_code == 404
+
+
+# ── Public endpoints stay public ────────────────────────────────
+
+
+class TestPublicEndpointsUnaffected:
+    """Token auth must not affect public endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_create_config_no_auth(self, client):
+        resp = await client.post("/api/v1/configs", json={
+            "external_assignment_id": "public-test-cfg",
+            "template_name": "input_output",
+            "languages": ["python"],
+            "criteria_config": {},
+        })
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_get_config_by_external_id_no_auth(self, client):
+        await client.post("/api/v1/configs", json={
+            "external_assignment_id": "public-ext-id",
+            "template_name": "input_output",
+            "languages": ["python"],
+            "criteria_config": {},
+        })
+        resp = await client.get("/api/v1/configs/public-ext-id")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_list_configs_no_auth(self, client):
+        resp = await client.get("/api/v1/configs")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_health_no_auth(self, client):
+        resp = await client.get("/api/v1/health")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_get_submission_no_auth(self, client):
+        resp = await client.get("/api/v1/submissions/99999")
+        assert resp.status_code == 404  # not 401
+
+    @pytest.mark.asyncio
+    async def test_list_user_submissions_no_auth(self, client):
+        resp = await client.get("/api/v1/submissions/user/nobody")
+        assert resp.status_code == 200

--- a/web/api/deps.py
+++ b/web/api/deps.py
@@ -23,7 +23,13 @@ async def require_integration_token(
     credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
 ) -> None:
     """Enforce Bearer-token auth on integration endpoints."""
-    config = get_integration_auth_config()
+    try:
+        config = get_integration_auth_config()
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Integration authentication is not configured",
+        ) from exc
 
     if credentials is None:
         raise HTTPException(

--- a/web/api/deps.py
+++ b/web/api/deps.py
@@ -1,7 +1,12 @@
 """Shared API dependencies."""
 
+import hmac
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from web.config.auth import get_integration_auth_config
 from web.database import get_session
 
 
@@ -9,4 +14,28 @@ async def get_db_session() -> AsyncSession:
     """Get database session dependency."""
     async with get_session() as session:
         yield session
+
+
+_bearer_scheme = HTTPBearer(auto_error=False)
+
+
+async def require_integration_token(
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+) -> None:
+    """Enforce Bearer-token auth on integration endpoints."""
+    config = get_integration_auth_config()
+
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing authentication token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    if not hmac.compare_digest(credentials.credentials, config.token):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 

--- a/web/api/v1/grading_configs.py
+++ b/web/api/v1/grading_configs.py
@@ -5,7 +5,7 @@ from typing import List
 from fastapi import APIRouter, HTTPException, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from web.api.deps import get_db_session
+from web.api.deps import get_db_session, require_integration_token
 from web.config.logging import get_logger
 from web.repositories import GradingConfigRepository
 from web.schemas import (
@@ -64,6 +64,32 @@ async def create_grading_config(
         db_config.template_name,
     )
     return db_config
+
+
+@router.get("/id/{config_id}", response_model=GradingConfigResponse, dependencies=[Depends(require_integration_token)])
+async def get_grading_config_by_id(
+    config_id: int,
+    session: AsyncSession = Depends(get_db_session)
+):
+    """Get grading configuration by internal config ID."""
+    logger.info("Fetching grading configuration by ID: config_id=%d", config_id)
+    repo = GradingConfigRepository(session)
+    config = await repo.get_by_id(config_id)
+
+    if not config:
+        logger.warning("Grading configuration not found: config_id=%d", config_id)
+        raise HTTPException(
+            status_code=404,
+            detail=f"Configuration with id {config_id} not found"
+        )
+
+    logger.info(
+        "Grading configuration fetched: config_id=%d, assignment=%s, template=%s",
+        config.id,
+        config.external_assignment_id,
+        config.template_name,
+    )
+    return config
 
 
 @router.get("/{external_assignment_id}", response_model=GradingConfigResponse)

--- a/web/api/v1/submissions.py
+++ b/web/api/v1/submissions.py
@@ -1,23 +1,28 @@
 """Submission endpoints."""
 
 import asyncio
+from datetime import datetime, timezone
 from typing import List
 
 from fastapi import APIRouter, HTTPException, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from web.api.deps import get_db_session
+from web.api.deps import get_db_session, require_integration_token
 from web.config.logging import get_logger
 from web.core.lifespan import get_grading_tasks
 from web.database.models.submission import SubmissionStatus
+from web.database.models.submission_result import PipelineStatus
 from web.repositories import (
     GradingConfigRepository,
     SubmissionRepository,
+    ResultRepository,
 )
 from web.schemas import (
     SubmissionCreate,
     SubmissionResponse,
     SubmissionDetailResponse,
+    ExternalResultCreate,
+    ExternalResultResponse,
 )
 from web.service.grading_service import grade_submission, GradingRequest
 
@@ -223,3 +228,118 @@ async def get_user_submissions(
     logger.info("Found %d submission(s) for user=%s", len(submissions), external_user_id)
     return submissions
 
+
+@router.post("/external-results", response_model=ExternalResultResponse, dependencies=[Depends(require_integration_token)])
+async def ingest_external_result(
+    payload: ExternalResultCreate,
+    session: AsyncSession = Depends(get_db_session)
+):
+    """Ingest an externally computed grading result.
+
+    Creates a submission row and a matching submission_result row from
+    results computed outside the cloud instance (e.g. GitHub Action in
+    external/private mode).
+    """
+    logger.info(
+        "External result ingestion: user=%s, config_id=%d, status=%s, score=%.2f",
+        payload.external_user_id,
+        payload.grading_config_id,
+        payload.status.value,
+        payload.final_score,
+    )
+
+    # Validate grading config exists
+    config_repo = GradingConfigRepository(session)
+    grading_config = await config_repo.get_by_id(payload.grading_config_id)
+    if not grading_config:
+        logger.warning(
+            "External result rejected: grading config not found config_id=%d (user=%s)",
+            payload.grading_config_id,
+            payload.external_user_id,
+        )
+        raise HTTPException(
+            status_code=404,
+            detail=f"Grading configuration with id {payload.grading_config_id} not found"
+        )
+
+    # Validate language is supported by this config
+    if payload.language not in grading_config.languages:
+        logger.warning(
+            "External result rejected: unsupported language '%s' for config_id=%d (supported=%s)",
+            payload.language,
+            payload.grading_config_id,
+            grading_config.languages,
+        )
+        raise HTTPException(
+            status_code=400,
+            detail=f"Language '{payload.language}' is not supported for this configuration. "
+                   f"Supported languages: {', '.join(grading_config.languages)}"
+        )
+
+    # Map external status to internal submission status
+    submission_status = (
+        SubmissionStatus.COMPLETED
+        if payload.status.value == "completed"
+        else SubmissionStatus.FAILED
+    )
+
+    # Map to pipeline status
+    pipeline_status = (
+        PipelineStatus.SUCCESS
+        if payload.status.value == "completed"
+        else PipelineStatus.FAILED
+    )
+
+    now = datetime.now(timezone.utc)
+
+    # Create submission record (no files — externally graded)
+    submission_repo = SubmissionRepository(session)
+    db_submission = await submission_repo.create(
+        grading_config_id=grading_config.id,
+        external_user_id=payload.external_user_id,
+        username=payload.username,
+        submission_files={},
+        language=payload.language,
+        status=submission_status,
+        submission_metadata=payload.submission_metadata,
+    )
+    db_submission.graded_at = now
+
+    # Flush to obtain the submission ID before creating the result row
+    await session.flush()
+
+    # Create submission result record
+    result_repo = ResultRepository(session)
+    await result_repo.create(
+        submission_id=db_submission.id,
+        final_score=payload.final_score,
+        result_tree=payload.result_tree,
+        feedback=payload.feedback,
+        focus=payload.focus,
+        pipeline_execution=payload.pipeline_execution,
+        execution_time_ms=payload.execution_time_ms,
+        pipeline_status=pipeline_status,
+        error_message=payload.error_message,
+    )
+
+    await session.commit()
+
+    logger.info(
+        "External result ingested: submission_id=%d, config_id=%d, user=%s, score=%.2f, status=%s",
+        db_submission.id,
+        grading_config.id,
+        payload.external_user_id,
+        payload.final_score,
+        submission_status.value,
+    )
+
+    return ExternalResultResponse(
+        submission_id=db_submission.id,
+        grading_config_id=grading_config.id,
+        external_user_id=payload.external_user_id,
+        username=payload.username,
+        status=submission_status,
+        final_score=payload.final_score,
+        graded_at=now,
+        execution_time_ms=payload.execution_time_ms,
+    )

--- a/web/api/v1/submissions.py
+++ b/web/api/v1/submissions.py
@@ -290,7 +290,7 @@ async def ingest_external_result(
         else PipelineStatus.FAILED
     )
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
 
     # Create submission record (no files — externally graded)
     submission_repo = SubmissionRepository(session)

--- a/web/config/auth.py
+++ b/web/config/auth.py
@@ -1,0 +1,23 @@
+"""Integration authentication configuration."""
+
+import os
+
+
+class IntegrationAuthConfig:
+
+    def __init__(self) -> None:
+        if "AUTOGRADER_INTEGRATION_TOKEN" not in os.environ:
+            raise ValueError(
+                "AUTOGRADER_INTEGRATION_TOKEN environment variable must be set"
+            )
+        self.token: str = os.environ["AUTOGRADER_INTEGRATION_TOKEN"]
+
+
+integration_auth_config: IntegrationAuthConfig | None = None
+
+
+def get_integration_auth_config() -> IntegrationAuthConfig:
+    global integration_auth_config
+    if integration_auth_config is None:
+        integration_auth_config = IntegrationAuthConfig()
+    return integration_auth_config

--- a/web/config/auth.py
+++ b/web/config/auth.py
@@ -10,7 +10,12 @@ class IntegrationAuthConfig:
             raise ValueError(
                 "AUTOGRADER_INTEGRATION_TOKEN environment variable must be set"
             )
-        self.token: str = os.environ["AUTOGRADER_INTEGRATION_TOKEN"]
+        token = os.environ["AUTOGRADER_INTEGRATION_TOKEN"].strip()
+        if not token:
+            raise ValueError(
+                "AUTOGRADER_INTEGRATION_TOKEN environment variable must be non-empty"
+            )
+        self.token: str = token
 
 
 integration_auth_config: IntegrationAuthConfig | None = None

--- a/web/schemas/__init__.py
+++ b/web/schemas/__init__.py
@@ -11,6 +11,8 @@ from web.schemas.submission import (
     SubmissionDetailResponse,
     SubmissionStatus,
     SubmissionFileData,
+    ExternalResultCreate,
+    ExternalResultResponse,
 )
 from web.schemas.execution import (
     DeliberateCodeExecutionRequest,
@@ -26,6 +28,8 @@ __all__ = [
     "SubmissionDetailResponse",
     "SubmissionStatus",
     "SubmissionFileData",
+    "ExternalResultCreate",
+    "ExternalResultResponse",
     "DeliberateCodeExecutionRequest",
     "DeliberateCodeExecutionResponse",
 ]

--- a/web/schemas/submission.py
+++ b/web/schemas/submission.py
@@ -79,3 +79,54 @@ class SubmissionDetailResponse(SubmissionResponse):
     submission_files: Dict[str, str]
     submission_metadata: Optional[Dict[str, Any]] = None
     pipeline_execution: Optional[Dict[str, Any]] = None  # NEW: Detailed pipeline execution info
+
+
+class ExternalResultStatus(str, Enum):
+    """Status of an externally graded submission."""
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class ExternalResultCreate(BaseModel):
+    """Schema for ingesting externally computed grading results."""
+    grading_config_id: int = Field(..., description="Internal grading configuration ID")
+    external_user_id: str = Field(..., description="External user ID from LMS/platform")
+    username: str = Field(..., description="Username of the submitter")
+    language: str = Field(..., description="Language the submission was graded in")
+    status: ExternalResultStatus = Field(..., description="Grading outcome: completed or failed")
+    final_score: float = Field(..., description="Final grading score", ge=0.0)
+    feedback: Optional[str] = Field(None, description="Generated feedback text")
+    result_tree: Optional[Dict[str, Any]] = Field(None, description="Scored result tree")
+    focus: Optional[Dict[str, Any]] = Field(None, description="Sorted failed tests by impact")
+    pipeline_execution: Optional[Dict[str, Any]] = Field(None, description="Pipeline step execution details")
+    execution_time_ms: int = Field(..., description="Total execution time in milliseconds", ge=0)
+    error_message: Optional[str] = Field(None, description="Error message for failed runs")
+    submission_metadata: Optional[Dict[str, Any]] = Field(None, description="Repository/run metadata")
+
+    @field_validator('language')
+    @classmethod
+    def validate_language(cls, v: str) -> str:
+        """Validate that the language is supported."""
+        language_upper = v.upper()
+        valid_languages = [lang.name for lang in Language]
+        if language_upper not in valid_languages:
+            valid_languages_lower = [lang.value for lang in Language]
+            raise ValueError(
+                f"Unsupported language '{v}'. "
+                f"Supported languages are: {', '.join(valid_languages_lower)}"
+            )
+        return Language[language_upper].value
+
+
+class ExternalResultResponse(BaseModel):
+    """Response after ingesting an external grading result."""
+    model_config = ConfigDict(from_attributes=True)
+
+    submission_id: int
+    grading_config_id: int
+    external_user_id: str
+    username: str
+    status: SubmissionStatus
+    final_score: float
+    graded_at: datetime
+    execution_time_ms: int


### PR DESCRIPTION
# [External Mode] Web API contract + M2M authentication for cloud integration

## Summary

Adds two new protected endpoints to support GitHub Action external/private mode, along with a mandatory bearer-token authentication layer for machine-to-machine cloud integration.

---

## What changed

### New endpoints

#### `GET /api/v1/configs/id/{config_id}` 
Fetches a full grading configuration by its internal database ID.
Required by the GitHub Action when operating in external mode, where only the `grading_config_id` is available.

Returns all fields needed to call `build_pipeline(...)`:
`template_name`, `criteria_config`, `setup_config`, `feedback_config`, `include_feedback`, `languages`, `external_assignment_id`, `version`, `is_active`.

#### `POST /api/v1/submissions/external-results` 
Ingests a grading result computed externally (e.g. inside the GitHub Action runner).

Creates a `submissions` row and a matching `submission_results` row. The result is immediately visible through the existing `GET /submissions/{id}` and `GET /submissions/user/{external_user_id}` endpoints.

Request payload:
| Field | Required | Notes |
|---|---|---|
| `grading_config_id` | ✅ | Internal config ID |
| `external_user_id` | ✅ | |
| `username` | ✅ | |
| `language` | ✅ | Must be supported by the config |
| `status` | ✅ | `completed` or `failed` |
| `final_score` | ✅ | `>= 0` |
| `execution_time_ms` | ✅ | `>= 0` |
| `feedback` | — | Optional |
| `result_tree` | — | Optional |
| `focus` | — | Optional |
| `pipeline_execution` | — | Optional |
| `error_message` | — | Optional, for failed runs |
| `submission_metadata` | — | Optional repo/run metadata |

### M2M authentication

Both new endpoints are protected with a Bearer token dependency.

- Token is read from `AUTOGRADER_INTEGRATION_TOKEN` environment variable (required — server raises `ValueError` at startup if unset)
- Validation uses `hmac.compare_digest` to prevent timing attacks
- Secrets are never logged
- Returns `401` for missing or invalid token
- All existing public endpoints are unaffected

### New schemas

- `ExternalResultStatus` — `completed | failed`
- `ExternalResultCreate` — request body with Pydantic validation
- `ExternalResultResponse` — response body

### Docs

`docs/API.md` updated with:
- Authentication section with setup instructions and usage examples
- New endpoint documentation with request/response examples
-  markers on protected endpoints in the overview table

---

## Tests

| File | Coverage |
|---|---|
| `tests/web/test_external_results.py` | 13 tests — success paths, 404, 400, 422 |
| `tests/web/test_integration_auth.py` | 13 tests — missing token, wrong token, valid token, public endpoints unaffected |

All 51 web tests pass (`test_external_results`, `test_integration_auth`, `test_routes`, `test_api_endpoints`).

---

## Files changed

```
web/config/auth.py                        new
web/api/deps.py                           modified
web/api/v1/grading_configs.py             modified
web/api/v1/submissions.py                 modified
web/schemas/submission.py                 modified
web/schemas/__init__.py                   modified
tests/web/test_external_results.py        new
tests/web/test_integration_auth.py        new
docs/API.md                               modified
```

---

