### PR TITLE
Add external mode for GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,22 @@ inputs:
     description: 'Whether to include/generate feedback. Use "true" or "false". Defaults to false.'
     required: false
     default: "false"
+  execution-mode:
+    description: 'Execution mode for the autograder. Use "repo" (default) for repository-config mode or "external" to load config from the Autograder Cloud.'
+    required: false
+    default: "repo"
+  grading-config-id:
+    description: "The grading configuration ID from the Autograder Cloud. Required when execution-mode is \"external\"."
+    required: false
+  autograder-cloud-url:
+    description: "The base URL of the Autograder Cloud instance. Required when execution-mode is \"external\"."
+    required: false
+  autograder-cloud-token:
+    description: "Authentication token for the Autograder Cloud API. Required when execution-mode is \"external\"."
+    required: false
+  submission-language:
+    description: "Programming language of the student submission (e.g. 'python', 'java'). Validated against the grading config's supported languages. Defaults to the first language in the config when omitted. Only used in external mode."
+    required: false
 
 # Defines the output variable of the action.
 outputs:
@@ -47,3 +63,8 @@ runs:
     OPENAI_KEY: ${{ inputs.openai-key }}
     APP_TOKEN: ${{ inputs.app-token }}
     INCLUDE_FEEDBACK: ${{ inputs.include-feedback }}
+    EXECUTION_MODE: ${{ inputs.execution-mode }}
+    GRADING_CONFIG_ID: ${{ inputs.grading-config-id }}
+    AUTOGRADER_CLOUD_URL: ${{ inputs.autograder-cloud-url }}
+    AUTOGRADER_CLOUD_TOKEN: ${{ inputs.autograder-cloud-token }}
+    SUBMISSION_LANGUAGE: ${{ inputs.submission-language }}

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,10 @@ inputs:
   submission-language:
     description: "Programming language of the student submission (e.g. 'python', 'java'). Validated against the grading config's supported languages. Defaults to the first language in the config when omitted. Only used in external mode."
     required: false
+  locale:
+    description: "Locale for feedback messages (e.g. 'en', 'pt-br'). Defaults to 'en'."
+    required: false
+    default: "en"
 
 # Defines the output variable of the action.
 outputs:
@@ -68,3 +72,4 @@ runs:
     AUTOGRADER_CLOUD_URL: ${{ inputs.autograder-cloud-url }}
     AUTOGRADER_CLOUD_TOKEN: ${{ inputs.autograder-cloud-token }}
     SUBMISSION_LANGUAGE: ${{ inputs.submission-language }}
+    LOCALE: ${{ inputs.locale }}

--- a/autograder/models/abstract/exporter.py
+++ b/autograder/models/abstract/exporter.py
@@ -1,7 +1,12 @@
 """Abstract interface for grade exporters."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from autograder.models.pipeline_execution import PipelineExecution
 
 
 class Exporter(ABC):
@@ -10,6 +15,13 @@ class Exporter(ABC):
 
     Any system that receives grading results (Upstash Redis, GitHub Classroom, etc.)
     must implement this interface to be usable with the pipeline's ExporterStep.
+
+    Subclasses that need access to the full pipeline execution (result tree,
+    focus data, execution time, etc.) should override
+    :meth:`export_with_context` instead of — or in addition to — :meth:`export`.
+    The default implementation of :meth:`export_with_context` extracts
+    ``user_id``, ``score``, and ``feedback`` from the execution and delegates
+    to :meth:`export`, so existing exporters require no changes.
     """
 
     @abstractmethod
@@ -23,4 +35,21 @@ class Exporter(ABC):
             feedback: Optional feedback text. Exporters may ignore this
                       if they only handle scores.
         """
-        pass
+
+    def export_with_context(self, pipeline_exec: "PipelineExecution") -> None:
+        """
+        Export a grading result with access to the full pipeline execution.
+
+        Override this in exporters that require richer data (e.g., result
+        tree, focus, execution time).  The default implementation extracts
+        ``user_id``, ``score``, and ``feedback`` from *pipeline_exec* and
+        delegates to :meth:`export`.
+
+        Args:
+            pipeline_exec: The completed :class:`~autograder.models.pipeline_execution.PipelineExecution`
+                containing all step results.
+        """
+        user_id = pipeline_exec.submission.user_id
+        score = pipeline_exec.get_grade_step_result().final_score
+        feedback: Optional[str] = pipeline_exec.get_feedback()
+        self.export(user_id, score, feedback)

--- a/autograder/steps/export_step.py
+++ b/autograder/steps/export_step.py
@@ -30,9 +30,11 @@ class ExporterStep(Step):
             PipelineExecution with an added StepResult indicating success or failure of the export operation
         """
         external_user_id = pipeline_exec.submission.user_id
-        score = pipeline_exec.get_grade_step_result().final_score
-
-        logger.info("Exporting result: external_user_id=%s, score=%.2f", external_user_id, score)
+        try:
+            score = pipeline_exec.get_grade_step_result().final_score
+            logger.info("Exporting result: external_user_id=%s, score=%.2f", external_user_id, score)
+        except (ValueError, AttributeError):
+            logger.info("Exporting result: external_user_id=%s (score unavailable)", external_user_id)
         self._exporter_service.export_with_context(pipeline_exec)
         logger.info("Result exported successfully: external_user_id=%s", external_user_id)
 

--- a/autograder/steps/export_step.py
+++ b/autograder/steps/export_step.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 
 from autograder.models.abstract.exporter import Exporter
 from autograder.models.abstract.step import Step
@@ -30,13 +29,11 @@ class ExporterStep(Step):
         Returns:
             PipelineExecution with an added StepResult indicating success or failure of the export operation
         """
-        # Extract external_user_id, score and optional feedback
         external_user_id = pipeline_exec.submission.user_id
         score = pipeline_exec.get_grade_step_result().final_score
-        feedback: Optional[str] = pipeline_exec.get_feedback()
 
         logger.info("Exporting result: external_user_id=%s, score=%.2f", external_user_id, score)
-        self._exporter_service.export(external_user_id, score, feedback)
+        self._exporter_service.export_with_context(pipeline_exec)
         logger.info("Result exported successfully: external_user_id=%s", external_user_id)
 
         # Return success result

--- a/docs/API.md
+++ b/docs/API.md
@@ -906,11 +906,11 @@ Content-Type: application/json
   "execution_time_ms": 3200,
   "error_message": null,
   "submission_metadata": {
-    "github_repository": "org/repo",
-    "github_sha": "abc123",
-    "github_run_id": "999",
-    "github_actor": "student1",
-    "github_ref": "refs/heads/main"
+    "repository": "org/repo",
+    "commit_sha": "abc123",
+    "run_id": "999",
+    "actor": "student1",
+    "ref": "refs/heads/main"
   }
 }
 ```

--- a/docs/API.md
+++ b/docs/API.md
@@ -853,6 +853,102 @@ GET /api/v1/ready
 
 ---
 
+## External Mode Integration
+
+This section describes how the Autograder GitHub Action in **external mode** interacts with the API. The action makes exactly two authenticated calls per grading run.
+
+### Integration sequence
+
+```
+1. GET  /api/v1/configs/id/{grading_config_id}     # fetch grading config
+2. POST /api/v1/submissions/external-results        # submit result (or failure)
+```
+
+Both endpoints require the `Authorization: Bearer <token>` header where the token matches `AUTOGRADER_INTEGRATION_TOKEN` on the server.
+
+### Config fetch
+
+```http
+GET /api/v1/configs/id/{grading_config_id}
+Authorization: Bearer <token>
+```
+
+Returns the full grading configuration object (see [Get Grading Configuration by Internal ID](#get-grading-configuration-by-internal-id)). The action uses the following fields from the response:
+
+| Field | Used for |
+|-------|----------|
+| `id` | Sent back as `grading_config_id` in the result payload |
+| `template_name` | Selects the grading template |
+| `criteria_config` | Grading rubric |
+| `languages` | Validates `submission-language`; defaults to `languages[0]` if omitted |
+| `include_feedback` | Whether to run the feedback step |
+| `setup_config` | Pre-flight setup commands and required files |
+| `feedback_config` | Reporter configuration |
+
+### Result submission (success)
+
+```http
+POST /api/v1/submissions/external-results
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "grading_config_id": 42,
+  "external_user_id": "github-actor-login",
+  "username": "github-actor-login",
+  "language": "python",
+  "status": "completed",
+  "final_score": 85.5,
+  "feedback": "## Grade: 85.5/100\n...",
+  "result_tree": { ... },
+  "focus": { ... },
+  "pipeline_execution": { ... },
+  "execution_time_ms": 3200,
+  "error_message": null,
+  "submission_metadata": {
+    "github_repository": "org/repo",
+    "github_sha": "abc123",
+    "github_run_id": "999",
+    "github_actor": "student1",
+    "github_ref": "refs/heads/main"
+  }
+}
+```
+
+### Result submission (failure)
+
+When grading fails, the action posts a failure payload before exiting non-zero:
+
+```json
+{
+  "grading_config_id": 42,
+  "external_user_id": "github-actor-login",
+  "username": "github-actor-login",
+  "language": "python",
+  "status": "failed",
+  "final_score": 0.0,
+  "feedback": null,
+  "result_tree": null,
+  "focus": null,
+  "pipeline_execution": null,
+  "execution_time_ms": 1500,
+  "error_message": "Sandbox timed out after 30 s",
+  "submission_metadata": { ... }
+}
+```
+
+### Error handling
+
+| Scenario | Action behaviour |
+|----------|-----------------|
+| `401` on config fetch | Exits non-zero; no result posted |
+| `404` on config fetch | Exits non-zero; no result posted |
+| 5xx / network error on config fetch | Retries with exponential back-off; then exits non-zero |
+| Grading raises exception | Posts failure payload, then exits non-zero |
+| `401` / `4xx` on result submission | Exits non-zero (failure recorded in Action log) |
+
+---
+
 ## Error Responses
 
 All endpoints use FastAPI's standard error response format:

--- a/docs/github_action/README.md
+++ b/docs/github_action/README.md
@@ -4,15 +4,32 @@ This module packages the Autograder as a Docker-based GitHub Action so repositor
 
 It is primarily designed for GitHub Classroom style workflows, but can be used by any repository that follows the expected directory contract.
 
-## What it does
+## Execution modes
 
-When a workflow runs:
+| Mode | How config is loaded | When to use |
+|------|---------------------|-------------|
+| `repo` (default) | From config files checked out inside `submission/.github/autograder/` | Repository-based setups where grading config lives in the student repo |
+| `external` | Fetched from the Autograder Cloud API at runtime | Centralised setups where a single Autograder Cloud instance manages all assignments |
+
+## What it does (repo mode)
+
+When a workflow runs in `repo` mode:
 
 1. Reads student files from `submission/`.
 2. Reads grading config from `submission/.github/autograder/`.
 3. Builds and executes the Autograder pipeline.
 4. Updates the GitHub check run with the final score.
 5. Optionally commits `relatorio.md` with feedback.
+
+## What it does (external mode)
+
+When a workflow runs in `external` mode:
+
+1. Fetches the grading configuration from the Autograder Cloud (`GET /api/v1/configs/id/{id}`).
+2. Reads student files from `submission/`.
+3. Builds and executes the Autograder pipeline.
+4. Posts the grading result back to the Autograder Cloud (`POST /api/v1/submissions/external-results`).
+5. If grading fails for any reason, posts a `failed` status payload before exiting non-zero.
 
 ## Internal architecture
 
@@ -24,6 +41,8 @@ When a workflow runs:
 | [`github_action/main.py`](https://github.com/webtech-network/autograder/blob/main/github_action/main.py) | Parses arguments, validates runtime options, reads submission files, and starts grading. |
 | [`github_action/github_action_service.py`](https://github.com/webtech-network/autograder/blob/main/github_action/github_action_service.py) | Builds pipeline from JSON configs and handles GitHub export operations. |
 | [`github_action/github_classroom_exporter.py`](https://github.com/webtech-network/autograder/blob/main/github_action/github_classroom_exporter.py) | Export adapter that reports score and feedback through `GithubActionService`. |
+| [`github_action/cloud_client.py`](https://github.com/webtech-network/autograder/blob/main/github_action/cloud_client.py) | HTTP client for the Autograder Cloud API (config fetch + result submission). Uses exponential back-off on 5xx/network errors; raises `CloudClientError` on 4xx. |
+| [`github_action/cloud_exporter.py`](https://github.com/webtech-network/autograder/blob/main/github_action/cloud_exporter.py) | Export adapter for external mode. Builds the `ExternalResultCreate` payload and calls `CloudClient`. Provides `submit_failure()` for the failure path. |
 
 ## Repository contract required by the Action
 
@@ -47,6 +66,8 @@ Inside that checkout, the Action expects:
 - `feedback-type: ai` requires `openai-key`.
 - The current notification logic looks for a check run named `grading`.
 - `include-feedback: "true"` enables feedback generation and may update `relatorio.md`.
+- In `external` mode, `include_feedback` is taken from the cloud config, **not** from the `include-feedback` action input.
+- In `external` mode, `submission-language` is validated against the `languages` list in the cloud config. Omitting it defaults to the first language in that list.
 
 ## Reference repository
 
@@ -55,4 +76,5 @@ Use **[`webtech-network/demo-autograder`](https://github.com/webtech-network/dem
 ## Next
 
 - Configuration details: [configuration.md](configuration.md)
+- External mode deep-dive: [external-mode.md](external-mode.md)
 - Demo walkthrough: [demo-autograder.md](demo-autograder.md)

--- a/docs/github_action/configuration.md
+++ b/docs/github_action/configuration.md
@@ -4,6 +4,8 @@ This page describes how to configure `webtech-network/autograder@main` in your w
 
 ## Recommended workflow skeleton
 
+### Repo mode (default)
+
 ```yaml
 name: Autograder
 on:
@@ -33,6 +35,37 @@ jobs:
           openai-key: ${{ secrets.ENGINE }}
 ```
 
+### External mode
+
+```yaml
+name: Autograder (External)
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  grading:
+    runs-on: ubuntu-latest
+    if: github.actor != 'github-classroom[bot]'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: submission
+
+      - name: Run Autograder
+        uses: webtech-network/autograder@main
+        with:
+          execution-mode: "external"
+          grading-config-id: "42"                              # internal DB id
+          autograder-cloud-url: ${{ secrets.AUTOGRADER_CLOUD_URL }}
+          autograder-cloud-token: ${{ secrets.AUTOGRADER_CLOUD_TOKEN }}
+          submission-language: "python"                        # optional
+          feedback-type: "default"
+          template-preset: "input_output"                      # required by the parser; value is ignored in external mode
+```
+
 ## Inputs
 
 From [`action.yml`](https://github.com/webtech-network/autograder/blob/main/action.yml):
@@ -40,12 +73,17 @@ From [`action.yml`](https://github.com/webtech-network/autograder/blob/main/acti
 | Input | Required | Default | Notes |
 |---|---:|---|---|
 | `github-token` | no | `${{ github.token }}` | Used for GitHub API operations (repo/check run access). |
-| `template-preset` | yes | - | Template key used by the grading pipeline. Built-ins include `webdev`, `api`, and `input_output`. |
+| `template-preset` | yes | - | Template key used by the grading pipeline. Built-ins include `webdev`, `api`, and `input_output`. In external mode the pipeline reads the template from the cloud config, but this field is still required by the parser. |
 | `feedback-type` | yes | - | `default` or `ai`. |
 | `custom-template` | no | - | Currently not usable because `template-preset: custom` is rejected by `github_action/main.py`. |
 | `openai-key` | no | - | Required only when `feedback-type` is `ai`. |
 | `app-token` | no | - | Optional token for repository access; if omitted, runtime falls back to `github-token`. |
-| `include-feedback` | no | `"false"` | Must be `"true"` or `"false"` string. Controls whether feedback step is included. |
+| `include-feedback` | no | `"false"` | Must be `"true"` or `"false"` string. Ignored in external mode (value is taken from the cloud config). |
+| `execution-mode` | no | `"repo"` | `"repo"` or `"external"`. Determines where grading configuration is loaded from. |
+| `grading-config-id` | no | - | Internal DB id of the grading config on the Autograder Cloud. Required when `execution-mode` is `external`. |
+| `autograder-cloud-url` | no | - | Base URL of the Autograder Cloud instance (e.g. `https://cloud.example.com`). Required when `execution-mode` is `external`. |
+| `autograder-cloud-token` | no | - | Integration token for the Autograder Cloud API. Required when `execution-mode` is `external`. Should be stored as a repository secret. |
+| `submission-language` | no | - | Language of the student submission (e.g. `python`, `java`). Validated against the cloud config's `languages` list. Defaults to the first language in the list when omitted. Only used in `external` mode. |
 
 ## Outputs
 
@@ -72,17 +110,28 @@ It also reads student files recursively from `submission/`, excluding `.git` and
 
 ## Secrets and permissions
 
-### Typical secrets
+### Repo mode secrets
 
 - `ENGINE` (or another secret mapped to `openai-key`) when using AI feedback.
 - Optional token secret mapped to `app-token` if you need separate credentials.
 
+### External mode secrets
+
+| Secret | Maps to input | Description |
+|--------|--------------|-------------|
+| `AUTOGRADER_CLOUD_URL` | `autograder-cloud-url` | Base URL of the Autograder Cloud instance |
+| `AUTOGRADER_CLOUD_TOKEN` | `autograder-cloud-token` | Integration token (set `AUTOGRADER_INTEGRATION_TOKEN` on the server) |
+
+> Generate a strong token on the server: `openssl rand -hex 32`
+
 ### Permissions
 
-`permissions: write-all` is commonly used because the Action may:
+`permissions: write-all` is required in **repo mode** because the Action may:
 
 - update the workflow check run with score summary;
 - commit `relatorio.md` when feedback is enabled.
+
+In **external mode**, no GitHub repository write operations are performed, so elevated permissions are not required.
 
 ## Troubleshooting
 
@@ -90,6 +139,12 @@ It also reads student files recursively from `submission/`, excluding `.git` and
 
 - Ensure your workflow checks out repository to `path: submission`.
 - Ensure config is at `submission/.github/autograder/criteria.json`.
+- This error only occurs in **repo mode**; in external mode, config is fetched from the cloud.
+
+### `grading-config-id`, `autograder-cloud-url`, or `autograder-cloud-token` missing
+
+- All three are required when `execution-mode` is `external`.
+- The entrypoint validates these before starting the pipeline and exits non-zero if any are absent.
 
 ### `OpenAI API key is required for AI feedback mode`
 
@@ -107,4 +162,5 @@ It also reads student files recursively from `submission/`, excluding `.git` and
 ## See also
 
 - Module internals: [README.md](README.md)
+- External mode deep-dive: [external-mode.md](external-mode.md)
 - Demo repository walkthrough: [demo-autograder.md](demo-autograder.md)

--- a/docs/github_action/external-mode.md
+++ b/docs/github_action/external-mode.md
@@ -1,0 +1,157 @@
+# External mode
+
+External mode lets the GitHub Action load grading configuration from a central **Autograder Cloud** instance instead of reading JSON files from the student repository. Results are posted back to the same instance, making every submission visible through the Cloud's submission endpoints.
+
+---
+
+## Overview
+
+In **repo mode** (the default), configuration travels with the student repository:
+
+```
+student repo  →  criteria.json / feedback.json / setup.json  →  pipeline  →  check run + relatorio.md
+```
+
+In **external mode**, configuration is owned by the instructor and hosted on the Cloud:
+
+```
+Autograder Cloud  →  grading config  →  pipeline  →  Autograder Cloud (result)
+```
+
+The student repository only needs to contain the source code under `submission/`. No config files are required.
+
+---
+
+## Call sequence
+
+```
+GitHub Action
+    │
+    ├─── GET /api/v1/configs/id/{grading_config_id}   ─────► Autograder Cloud
+    │         (auth: AUTOGRADER_CLOUD_TOKEN)                       │
+    │◄────────────────────────────────────────────────────── config JSON
+    │
+    ├─── build_pipeline(criteria_config, template, …)
+    │
+    ├─── run_autograder(pipeline, student_name, files)
+    │         (grading runs locally inside the Action container)
+    │
+    └─── POST /api/v1/submissions/external-results    ─────► Autograder Cloud
+              (auth: AUTOGRADER_CLOUD_TOKEN)
+```
+
+### Failure path
+
+If grading raises an exception after the config is fetched, a failure payload (`status: "failed"`, `final_score: 0`) is submitted to the Cloud **before** the Action exits non-zero. This guarantees the Cloud always records a terminal state for every run.
+
+```
+run_autograder() raises
+    │
+    ├─── POST /api/v1/submissions/external-results  (status: "failed")
+    │
+    └─── SystemExit(1)
+```
+
+If the config fetch itself fails (network error, 404, invalid token), no result is posted and the Action exits non-zero immediately.
+
+---
+
+## Required secrets
+
+Configure these as **repository secrets** (or organization secrets shared across classroom repos):
+
+| Secret | Description |
+|--------|-------------|
+| `AUTOGRADER_CLOUD_URL` | Base URL of your Autograder Cloud instance, e.g. `https://autograder.myschool.edu` |
+| `AUTOGRADER_CLOUD_TOKEN` | Integration token (`AUTOGRADER_INTEGRATION_TOKEN` value set on the server) |
+
+> Generate a strong token: `openssl rand -hex 32`
+
+---
+
+## Workflow example
+
+```yaml
+name: Autograder (External)
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  grading:
+    runs-on: ubuntu-latest
+    if: github.actor != 'github-classroom[bot]'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: submission
+
+      - name: Run Autograder
+        uses: webtech-network/autograder@main
+        with:
+          execution-mode: "external"
+          grading-config-id: "42"
+          autograder-cloud-url: ${{ secrets.AUTOGRADER_CLOUD_URL }}
+          autograder-cloud-token: ${{ secrets.AUTOGRADER_CLOUD_TOKEN }}
+          submission-language: "python"
+          feedback-type: "default"
+          template-preset: "input_output"    # required by the parser; value unused in external mode
+```
+
+### `submission-language`
+
+- Optional. When omitted, the first language in the cloud config's `languages` list is used.
+- When provided, it is validated against the `languages` list. An unsupported value causes the Action to exit non-zero **without posting a result**.
+
+---
+
+## Step-by-step setup
+
+1. **Deploy the Autograder Cloud** and confirm the API is reachable.
+2. **Generate an integration token** and set `AUTOGRADER_INTEGRATION_TOKEN` on the server.
+3. **Create a grading configuration** via `POST /api/v1/configs` and note the returned `id`.
+4. **Add secrets** `AUTOGRADER_CLOUD_URL` and `AUTOGRADER_CLOUD_TOKEN` to the repository (or organisation).
+5. **Add the workflow file** above to `.github/workflows/autograder.yml` in each student repository.
+6. **Push a submission** and verify a result appears under `GET /api/v1/submissions/config/{id}`.
+
+---
+
+## Differences from repo mode
+
+| Behaviour | Repo mode | External mode |
+|-----------|-----------|---------------|
+| Config source | `submission/.github/autograder/*.json` | Autograder Cloud API |
+| `include_feedback` | From `include-feedback` action input | From cloud config |
+| Result export | GitHub check run + `relatorio.md` | Autograder Cloud API |
+| Repository write permissions needed | Yes (`write-all`) | No |
+| Failure reporting | GitHub check run status | `POST /api/v1/submissions/external-results` with `status: "failed"` |
+
+---
+
+## Troubleshooting
+
+### `CloudClientError: 401`
+The `AUTOGRADER_CLOUD_TOKEN` does not match the server's `AUTOGRADER_INTEGRATION_TOKEN`.  Regenerate and update both.
+
+### `CloudClientError: 404`
+The `grading-config-id` does not exist on the server.  Verify the id with `GET /api/v1/configs`.
+
+### `ValueError: Language 'X' not supported`
+The `submission-language` value is not in the config's `languages` list.  Update the cloud config or correct the workflow input.
+
+### `ValueError: Config has no languages defined`
+The cloud config's `languages` list is empty.  Update the config to include at least one language.
+
+### Action exits non-zero but no result on Cloud
+Config fetch failed before any result could be posted.  Check the Action log for the specific error (network, auth, or missing arguments).
+
+---
+
+## See also
+
+- [configuration.md](configuration.md) — full inputs reference
+- [README.md](README.md) — module architecture
+- [API documentation](../API.md) — Cloud API endpoints
+- [Rollout guide](../guides/external-mode-rollout.md) — migration and operational checklist

--- a/docs/guides/external-mode-rollout.md
+++ b/docs/guides/external-mode-rollout.md
@@ -1,0 +1,132 @@
+# External mode — rollout guide
+
+This guide is aimed at instructors and platform operators who want to adopt external mode for the first time, or migrate existing repo-mode workflows to it.
+
+---
+
+## Who is this for
+
+- You manage a multi-repository classroom and want a single place to configure grading criteria.
+- You want grading results stored centrally (in the Autograder Cloud database) rather than scattered across individual check runs.
+- You are already running repo mode and want to migrate without disrupting active submissions.
+
+---
+
+## Migration guidance
+
+### From repo mode
+
+Existing repo-mode workflows **continue to work without any changes**. External mode is opt-in: a workflow only enters external mode when `execution-mode: "external"` is set.
+
+You can run both modes side by side during a transition:
+
+1. Leave existing repo-mode workflows untouched.
+2. For new assignments, create a grading config on the Cloud and use the external-mode workflow template.
+3. For existing assignments, migrate one at a time: create the equivalent Cloud config, update the workflow, and remove the `.github/autograder/` files from the student repo template.
+
+### Config parity checklist
+
+When converting a repo-mode config to a Cloud config:
+
+| Repo-mode file | Cloud config field |
+|----------------|--------------------|
+| `criteria.json` | `criteria_config` |
+| `feedback.json` | `feedback_config` |
+| `setup.json` | `setup_config` |
+| `template-preset` action input | `template_name` |
+| `include-feedback` action input | `include_feedback` |
+
+---
+
+## New secrets required
+
+For each repository (or at organisation level):
+
+| Secret name | Value |
+|-------------|-------|
+| `AUTOGRADER_CLOUD_URL` | Base URL of your Autograder Cloud, e.g. `https://autograder.myschool.edu` |
+| `AUTOGRADER_CLOUD_TOKEN` | Token matching `AUTOGRADER_INTEGRATION_TOKEN` on the server |
+
+Generate the token once on the server and reuse it across all repositories:
+
+```bash
+openssl rand -hex 32
+```
+
+Set it as the `AUTOGRADER_INTEGRATION_TOKEN` environment variable on the server **before** starting the API. The server will fail to start the integration auth configuration if the variable is absent or empty.
+
+---
+
+## Operational checklist
+
+### Server side
+
+- [ ] `AUTOGRADER_INTEGRATION_TOKEN` is set and non-empty.
+- [ ] The API is reachable from GitHub Actions runners (`https://your-cloud-url/api/v1/health` returns 200).
+- [ ] Grading configuration created via `POST /api/v1/configs` — note the returned `id`.
+- [ ] Config includes at least one entry in `languages`.
+
+### Workflow side
+
+- [ ] `AUTOGRADER_CLOUD_URL` secret is set on the repository (or organisation).
+- [ ] `AUTOGRADER_CLOUD_TOKEN` secret is set on the repository (or organisation).
+- [ ] `execution-mode: "external"` in the workflow.
+- [ ] `grading-config-id` matches the `id` from the server.
+- [ ] `template-preset` is set to any valid value (required by the argument parser, not used in external mode).
+- [ ] `permissions: write-all` removed (not needed in external mode).
+
+---
+
+## Smoke test
+
+Run the following smoke test after setup to verify the full integration works end-to-end before deploying to students.
+
+### 1 — Verify the Cloud is reachable and configured
+
+```bash
+# Health check
+curl https://your-cloud-url/api/v1/health
+
+# Verify the config exists and token is accepted
+curl -H "Authorization: Bearer $AUTOGRADER_CLOUD_TOKEN" \
+     https://your-cloud-url/api/v1/configs/id/42
+```
+
+### 2 — Trigger a test run
+
+Push a known-good submission to a test repository that has the external-mode workflow. Observe:
+
+- Action completes without non-zero exit.
+- Result appears on the Cloud:
+
+```bash
+curl https://your-cloud-url/api/v1/submissions/config/42
+```
+
+### 3 — Verify a failure is recorded
+
+Trigger a run with a deliberately broken submission (e.g. syntax error). Verify:
+
+- Action exits with code 1.
+- A `status: "failed"` record appears under `GET /api/v1/submissions/config/42`.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Action exits 1 with `401` in log | Wrong token | Regenerate and sync `AUTOGRADER_INTEGRATION_TOKEN` and `AUTOGRADER_CLOUD_TOKEN` |
+| Action exits 1 with `404` in log | Wrong config id | Check `grading-config-id` against `GET /api/v1/configs` |
+| Action exits 1 with `ValueError: Language 'X' not supported` | Language not in config | Add the language to the Cloud config or fix `submission-language` |
+| Action exits 1 with `ValueError: Config has no languages defined` | Config `languages` is `[]` | Update the config to include at least one language |
+| No result on Cloud after successful run | Config fetch succeeded but result post failed | Check Action log for error on the POST step |
+| Server returns 503 on protected endpoints | `AUTOGRADER_INTEGRATION_TOKEN` not set on server | Set the env var and restart the API |
+
+---
+
+## See also
+
+- [External mode deep-dive](../github_action/external-mode.md)
+- [Configuration reference](../github_action/configuration.md)
+- [API documentation](../API.md)

--- a/github_action/cloud_client.py
+++ b/github_action/cloud_client.py
@@ -1,0 +1,238 @@
+
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Public exception types
+# ---------------------------------------------------------------------------
+
+class CloudClientError(Exception):
+    """
+    Raised when the Autograder Cloud API returns a 4xx response.
+
+    This indicates a *client-side* mistake (wrong config ID, bad token, etc.)
+    that will not be resolved by retrying.
+
+    Attributes:
+        status_code: The HTTP status code returned by the server.
+        message: Human-readable description without secrets.
+    """
+
+    def __init__(self, message: str, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+class CloudConnectionError(Exception):
+    """
+    Raised when the Autograder Cloud API cannot be reached or consistently
+    returns 5xx responses after all retry attempts are exhausted.
+    """
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CONNECT_TIMEOUT: float = 10.0
+_DEFAULT_READ_TIMEOUT: float = 30.0
+_DEFAULT_MAX_RETRIES: int = 3
+_RETRY_BASE_DELAY: float = 1.0  # seconds; doubled on each subsequent attempt
+
+class CloudClient:
+    """
+    Thin HTTP client for the Autograder Cloud REST API.
+
+    Args:
+        cloud_url: Base URL of the Autograder Cloud instance
+            (e.g. ``"https://cloud.example.com"``).  Trailing slashes are
+            stripped automatically.
+        cloud_token: Bearer token used for ``Authorization`` headers. Never
+            logged or included in exception messages.
+        connect_timeout: Seconds to wait while establishing a TCP connection.
+            Stored as metadata; the underlying socket timeout uses
+            ``read_timeout`` (the dominant concern in CI pipelines).
+        read_timeout: Seconds to wait for the server to send data after a
+            connection is established.  Used as the ``urllib`` socket timeout.
+        max_retries: Maximum number of *additional* attempts after the first
+            failure for transient errors (5xx / network).  Set to ``0`` to
+            disable retries.
+    """
+
+    def __init__(
+        self,
+        cloud_url: str,
+        cloud_token: str,
+        *,
+        connect_timeout: float = _DEFAULT_CONNECT_TIMEOUT,
+        read_timeout: float = _DEFAULT_READ_TIMEOUT,
+        max_retries: int = _DEFAULT_MAX_RETRIES,
+    ) -> None:
+        self._base_url = cloud_url.rstrip("/")
+        self._cloud_token = cloud_token
+        self.connect_timeout = connect_timeout
+        self.read_timeout = read_timeout
+        self.max_retries = max_retries
+
+    # ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+    def get_grading_config(self, config_id: str) -> dict:
+        """
+        Fetch a grading configuration from the cloud by its ID.
+
+        Args:
+            config_id: The unique identifier of the grading configuration.
+
+        Returns:
+            Parsed JSON payload as a ``dict``.
+
+        Raises:
+            CloudClientError: The server returned a 4xx status.
+            CloudConnectionError: The server returned persistent 5xx responses
+                or could not be reached after all retries.
+        """
+        url = f"{self._base_url}/api/v1/configs/id/{config_id}"
+        logger.debug("Fetching grading config '%s' from %s", config_id, url)
+        return self._get(url, context_label=f"grading config '{config_id}'")
+
+    def submit_external_result(self, payload: dict) -> dict:
+        """
+        Publish a grading result to the Autograder Cloud.
+
+        Args:
+            payload: Serialisable dict containing score, feedback, tree, and
+                GitHub context metadata.  See :class:`CloudExporter` for the
+                canonical schema.
+
+        Returns:
+            Parsed JSON response from the server (may be an empty ``{}``).
+
+        Raises:
+            CloudClientError: The server returned a 4xx status.
+            CloudConnectionError: The server returned persistent 5xx responses
+                or could not be reached after all retries.
+        """
+        url = f"{self._base_url}/api/v1/submissions/external-results"
+        logger.debug("Submitting external result to %s", url)
+        return self._post(url, payload, context_label="result submission")
+
+    # ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+    def _get(self, url: str, *, context_label: str) -> dict:
+        req = urllib.request.Request(
+            url,
+            method="GET",
+            headers=self._auth_headers(),
+        )
+        return self._request_with_retry(req, context_label=context_label)
+
+    def _post(self, url: str, payload: dict, *, context_label: str) -> dict:
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            url,
+            data=body,
+            method="POST",
+            headers={**self._auth_headers(), "Content-Type": "application/json"},
+        )
+        return self._request_with_retry(req, context_label=context_label)
+
+    def _auth_headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._cloud_token}",
+            "Accept": "application/json",
+        }
+
+    def _request_with_retry(self, req: urllib.request.Request, *, context_label: str) -> dict:
+        """
+        Execute *req* with retry logic for transient failures.
+
+        4xx responses raise :class:`CloudClientError` immediately (no retry).
+        5xx and network errors are retried up to ``self.max_retries`` times
+        with exponential back-off.
+
+        Args:
+            req: Prepared :class:`urllib.request.Request` to send.
+            context_label: Human-readable label for the operation used in
+                error messages (must not contain secret values).
+
+        Returns:
+            Parsed JSON response body as a ``dict``.
+
+        Raises:
+            CloudClientError: Non-retryable 4xx response.
+            CloudConnectionError: Retries exhausted or persistent server error.
+        """
+        last_error: Exception | None = None
+
+        for attempt in range(self.max_retries + 1):
+            if attempt > 0:
+                delay = _RETRY_BASE_DELAY * (2 ** (attempt - 1))
+                logger.warning(
+                    "Retrying %s (attempt %d/%d) after %.1fs back-off…",
+                    context_label,
+                    attempt,
+                    self.max_retries,
+                    delay,
+                )
+                time.sleep(delay)
+
+            try:
+                with urllib.request.urlopen(req, timeout=self.read_timeout) as response:  # noqa: S310
+                    body = response.read().decode("utf-8")
+                return self._parse_json(body, context_label)
+
+            except urllib.error.HTTPError as exc:
+                if 400 <= exc.code < 500:
+                    # Client error — do NOT retry
+                    raise CloudClientError(
+                        f"Autograder Cloud returned HTTP {exc.code} for {context_label}. "
+                        "Check your configuration ID, cloud URL, and token.",
+                        status_code=exc.code,
+                    ) from exc
+
+                # 5xx — transient; record and retry
+                logger.warning(
+                    "Autograder Cloud returned HTTP %d for %s (attempt %d/%d).",
+                    exc.code,
+                    context_label,
+                    attempt + 1,
+                    self.max_retries + 1,
+                )
+                last_error = exc
+
+            except urllib.error.URLError as exc:
+                logger.warning(
+                    "Network error reaching Autograder Cloud for %s (attempt %d/%d): %s",
+                    context_label,
+                    attempt + 1,
+                    self.max_retries + 1,
+                    exc.reason,
+                )
+                last_error = exc
+
+        raise CloudConnectionError(
+            f"Could not complete {context_label} after {self.max_retries + 1} attempt(s). "
+            "Check that autograder-cloud-url is reachable and the service is healthy."
+        ) from last_error
+
+    @staticmethod
+    def _parse_json(body: str, context_label: str) -> dict[str, Any]:
+        if not body.strip():
+            return {}
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError as exc:
+            raise CloudConnectionError(
+                f"Autograder Cloud returned an invalid JSON response for {context_label}."
+            ) from exc

--- a/github_action/cloud_exporter.py
+++ b/github_action/cloud_exporter.py
@@ -1,0 +1,204 @@
+
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Optional, TYPE_CHECKING
+
+from autograder.models.abstract.exporter import Exporter
+from github_action.cloud_client import CloudClient
+
+if TYPE_CHECKING:
+    from autograder.models.pipeline_execution import PipelineExecution, PipelineStatus
+
+logger = logging.getLogger(__name__)
+
+class CloudExporter(Exporter):
+    """
+    Exporter implementation for the *external* GitHub Action execution mode.
+
+    Builds a rich payload from the completed
+    :class:`~autograder.models.pipeline_execution.PipelineExecution` and
+    submits it to the Autograder Cloud
+    ``POST /api/v1/submissions/external-results`` endpoint.
+
+    Args:
+        client: Configured :class:`~github_action.cloud_client.CloudClient`
+            instance used to communicate with the cloud API.
+        grading_config_id: The internal (integer) grading-configuration ID
+            returned by the cloud API.  Used for server-side correlation.
+        language: Submission language (e.g. ``"python"``, ``"java"``).
+            Must match a value accepted by the cloud API.
+        student_name: GitHub username / student identifier.  Used for both
+            ``external_user_id`` and ``username`` fields in the payload.
+    """
+
+    def __init__(
+        self,
+        client: CloudClient,
+        grading_config_id: int,
+        language: str,
+        student_name: str,
+    ) -> None:
+        self._client = client
+        self._grading_config_id = grading_config_id
+        self._language = language
+        self._student_name = student_name
+
+    # ---------------------------------------------------------------------------
+# Exporter interface
+# ---------------------------------------------------------------------------
+
+    def export_with_context(self, pipeline_exec: "PipelineExecution") -> None:
+        """
+        Build and submit the full grading payload using the complete pipeline
+        execution data.
+
+        This is the primary entry point called by
+        :class:`~autograder.steps.export_step.ExporterStep`.  It collects
+        score, feedback, result tree, focus analysis, execution time, and
+        GitHub context then calls
+        :meth:`~github_action.cloud_client.CloudClient.submit_external_result`.
+
+        Args:
+            pipeline_exec: The completed pipeline execution.
+        """
+        payload = self._build_payload(pipeline_exec)
+        logger.info(
+            "Submitting external result for config %d: score=%.2f, status=%s",
+            self._grading_config_id,
+            payload.get("final_score", 0.0),
+            payload.get("status"),
+        )
+        self._client.submit_external_result(payload)
+
+    def export(self, user_id: str, score: float, feedback: Optional[str] = None) -> None:
+        """
+        Fallback export using only the minimal ``(user_id, score, feedback)``
+        triple.  Called when :meth:`export_with_context` is not invoked
+        directly (e.g. in tests that bypass the pipeline).
+        """
+        payload = self._build_minimal_payload(user_id, score, feedback)
+        logger.info(
+            "Submitting minimal external result for config %d: score=%.2f",
+            self._grading_config_id,
+            score,
+        )
+        self._client.submit_external_result(payload)
+
+    def submit_failure(self, error_message: str, execution_time_ms: int = 0) -> None:
+        """
+        Submit a failure payload to the cloud API.
+
+        Called when the grading pipeline fails before the
+        :class:`~autograder.steps.export_step.ExporterStep` runs, so that the
+        cloud still records a terminal state for the submission.
+
+        Args:
+            error_message: Human-readable description of the failure.
+            execution_time_ms: Total elapsed time in milliseconds up to the
+                point of failure.
+        """
+        payload = {
+            "grading_config_id": self._grading_config_id,
+            "external_user_id": self._student_name,
+            "username": self._student_name,
+            "language": self._language,
+            "status": "failed",
+            "final_score": 0.0,
+            "execution_time_ms": execution_time_ms,
+            "error_message": error_message,
+            "submission_metadata": self._get_github_context(),
+        }
+        logger.info(
+            "Submitting failure payload for config %d: %s",
+            self._grading_config_id,
+            error_message,
+        )
+        self._client.submit_external_result(payload)
+
+    # ---------------------------------------------------------------------------
+# Payload builders
+# ---------------------------------------------------------------------------
+
+    def _build_payload(self, pipeline_exec: "PipelineExecution") -> dict:
+        """
+        Construct the full result payload matching the ``ExternalResultCreate``
+        schema expected by ``POST /api/v1/submissions/external-results``.
+        """
+        status = "completed"
+        error_message: Optional[str] = None
+
+        try:
+            final_score = pipeline_exec.get_grade_step_result().final_score
+        except (ValueError, AttributeError) as exc:
+            final_score = 0.0
+            status = "failed"
+            error_message = str(exc)
+
+        feedback = pipeline_exec.get_feedback()
+
+        result_tree_dict: Optional[dict] = None
+        try:
+            result_tree = pipeline_exec.get_result_tree()
+            result_tree_dict = result_tree.to_dict()
+        except (ValueError, AttributeError):
+            pass
+
+        focus_dict: Optional[dict] = None
+        try:
+            focus = pipeline_exec.get_focus()
+            focus_dict = focus.to_dict()
+        except (ValueError, AttributeError):
+            pass
+
+        execution_time_ms = int((time.time() - pipeline_exec.start_time) * 1000)
+
+        return {
+            "grading_config_id": self._grading_config_id,
+            "external_user_id": self._student_name,
+            "username": self._student_name,
+            "language": self._language,
+            "status": status,
+            "final_score": final_score,
+            "feedback": feedback,
+            "result_tree": result_tree_dict,
+            "focus": focus_dict,
+            "pipeline_execution": None,
+            "execution_time_ms": execution_time_ms,
+            "error_message": error_message,
+            "submission_metadata": self._get_github_context(),
+        }
+
+    def _build_minimal_payload(
+        self, user_id: str, score: float, feedback: Optional[str]
+    ) -> dict:
+        """Build a minimal valid payload when no pipeline execution context is available."""
+        return {
+            "grading_config_id": self._grading_config_id,
+            "external_user_id": user_id,
+            "username": user_id,
+            "language": self._language,
+            "status": "completed",
+            "final_score": score,
+            "feedback": feedback,
+            "result_tree": None,
+            "focus": None,
+            "pipeline_execution": None,
+            "execution_time_ms": 0,
+            "error_message": None,
+            "submission_metadata": self._get_github_context(),
+        }
+
+    @staticmethod
+    def _get_github_context() -> dict:
+        """Read GitHub Actions runtime environment variables."""
+        return {
+            "repository": os.getenv("GITHUB_REPOSITORY"),
+            "commit_sha": os.getenv("GITHUB_SHA"),
+            "run_id": os.getenv("GITHUB_RUN_ID"),
+            "actor": os.getenv("GITHUB_ACTOR"),
+            "ref": os.getenv("GITHUB_REF"),
+        }

--- a/github_action/cloud_exporter.py
+++ b/github_action/cloud_exporter.py
@@ -11,7 +11,7 @@ from autograder.models.abstract.exporter import Exporter
 from github_action.cloud_client import CloudClient
 
 if TYPE_CHECKING:
-    from autograder.models.pipeline_execution import PipelineExecution, PipelineStatus
+    from autograder.models.pipeline_execution import PipelineExecution
 
 logger = logging.getLogger(__name__)
 

--- a/github_action/entrypoint.sh
+++ b/github_action/entrypoint.sh
@@ -22,6 +22,26 @@ if [[ -z "$GITHUB_ACTOR" ]]; then
   echo "Error: Environment variable GITHUB_ACTOR is not set." >&2
   exit 1
 fi
+
+# --- 1b. Mode-specific validation ---
+# Resolve effective execution mode (default: repo)
+EFFECTIVE_MODE="${EXECUTION_MODE:-repo}"
+
+if [[ "$EFFECTIVE_MODE" == "external" ]]; then
+  if [[ -z "$GRADING_CONFIG_ID" ]]; then
+    echo "Error: GRADING_CONFIG_ID is required when execution-mode is 'external'." >&2
+    exit 1
+  fi
+  if [[ -z "$AUTOGRADER_CLOUD_URL" ]]; then
+    echo "Error: AUTOGRADER_CLOUD_URL is required when execution-mode is 'external'." >&2
+    exit 1
+  fi
+  if [[ -z "$AUTOGRADER_CLOUD_TOKEN" ]]; then
+    echo "Error: AUTOGRADER_CLOUD_TOKEN is required when execution-mode is 'external'." >&2
+    exit 1
+  fi
+fi
+
 cd /app
 
 
@@ -34,6 +54,7 @@ args=(
     "--github-token" "$GITHUB_TOKEN"
     "--template-preset" "$TEMPLATE_PRESET"
     "--student-name" "$GITHUB_ACTOR"
+    "--execution-mode" "$EFFECTIVE_MODE"
 )
 
 # Conditionally add optional arguments to the array ONLY if they are set.
@@ -53,6 +74,22 @@ fi
 
 if [[ -n "$INCLUDE_FEEDBACK" ]]; then
   args+=("--include-feedback" "$INCLUDE_FEEDBACK")
+fi
+
+if [[ -n "$GRADING_CONFIG_ID" ]]; then
+    args+=("--grading-config-id" "$GRADING_CONFIG_ID")
+fi
+
+if [[ -n "$AUTOGRADER_CLOUD_URL" ]]; then
+    args+=("--autograder-cloud-url" "$AUTOGRADER_CLOUD_URL")
+fi
+
+if [[ -n "$AUTOGRADER_CLOUD_TOKEN" ]]; then
+    args+=("--autograder-cloud-token" "$AUTOGRADER_CLOUD_TOKEN")
+fi
+
+if [[ -n "$SUBMISSION_LANGUAGE" ]]; then
+    args+=("--submission-language" "$SUBMISSION_LANGUAGE")
 fi
 
 

--- a/github_action/entrypoint.sh
+++ b/github_action/entrypoint.sh
@@ -92,6 +92,10 @@ if [[ -n "$SUBMISSION_LANGUAGE" ]]; then
     args+=("--submission-language" "$SUBMISSION_LANGUAGE")
 fi
 
+if [[ -n "$LOCALE" ]]; then
+    args+=("--locale" "$LOCALE")
+fi
+
 
 # --- 3. Execute the Python Script ---
 echo "Executing python entrypoint with configured arguments..."

--- a/github_action/github_action_service.py
+++ b/github_action/github_action_service.py
@@ -244,6 +244,7 @@ class GithubActionService:
         feedback_mode: str,
         student_name: str,
         submission_language: Optional[str] = None,
+        locale: str = "en",
     ) -> AutograderPipeline:
         """
         Build the autograder pipeline using configuration fetched from the Autograder Cloud.
@@ -309,6 +310,7 @@ class GithubActionService:
             feedback_mode=feedback_mode,
             export_results=True,
             exporter=exporter,
+            locale=locale,
         )
 
     def submit_failure_to_cloud(self, error_message: str, execution_time_ms: int = 0) -> None:

--- a/github_action/github_action_service.py
+++ b/github_action/github_action_service.py
@@ -1,14 +1,20 @@
 import json
+import logging
 import os
+from typing import Optional
 
 from autograder.autograder import build_pipeline, AutograderPipeline
 from autograder.models.dataclass.submission import Submission
+from github_action.cloud_client import CloudClient
+from github_action.cloud_exporter import CloudExporter
 from github_action.github_classroom_exporter import GithubClassroomExporter
 from github import Github
 from github.GithubException import UnknownObjectException
 from github.Repository import Repository
 from github.WorkflowRun import WorkflowRun
 from github.CheckRun import CheckRun
+
+logger = logging.getLogger(__name__)
 
 
 class GithubActionService:
@@ -30,6 +36,7 @@ class GithubActionService:
         self.github_token = github_token
         self.app_token = app_token
         self.repo = self.get_repository(app_token)
+        self._cloud_exporter: Optional[CloudExporter] = None
 
     def run_autograder(
         self, pipeline: AutograderPipeline, user_name: str, submission_files: dict
@@ -225,6 +232,103 @@ class GithubActionService:
             export_results=True,
             exporter=exporter,
         )
+
+    def autograder_pipeline_from_cloud(
+        self,
+        grading_config_id: str,
+        cloud_url: str,
+        cloud_token: str,
+        feedback_mode: str,
+        student_name: str,
+        submission_language: Optional[str] = None,
+    ) -> AutograderPipeline:
+        """
+        Build the autograder pipeline using configuration fetched from the Autograder Cloud.
+
+        Fetches the grading configuration via :class:`~github_action.cloud_client.CloudClient`
+        and registers a :class:`~github_action.cloud_exporter.CloudExporter` so that the
+        pipeline submits results back to the cloud instead of to GitHub Classroom.
+
+        The ``include_feedback`` setting is taken directly from the fetched configuration.
+        The submission language is validated against the config's ``languages`` list; if
+        ``submission_language`` is ``None`` the first language in the list is used.
+
+        Args:
+            grading_config_id: Internal grading configuration ID from the cloud.
+            cloud_url: Base URL of the Autograder Cloud instance.
+            cloud_token: Authentication token for the cloud API.
+            feedback_mode: The feedback mode to use (e.g. ``"default"`` or ``"ai"``).
+            student_name: GitHub username of the submitting student.
+            submission_language: Programming language of the submission.  If
+                ``None``, defaults to the first language listed in the config.
+
+        Returns:
+            AutograderPipeline: The constructed autograder pipeline.
+
+        Raises:
+            ValueError: ``submission_language`` is provided but not listed in the
+                grading configuration's ``languages`` field.
+            ~github_action.cloud_client.CloudClientError: Cloud returned a 4xx response.
+            ~github_action.cloud_client.CloudConnectionError: Cloud unreachable or 5xx.
+        """
+        client = CloudClient(cloud_url, cloud_token)
+        config = client.get_grading_config(grading_config_id)
+
+        # Resolve language: validate explicit declaration or default to first in config.
+        supported_languages: list[str] = config.get("languages", [])
+        if submission_language:
+            normalised = submission_language.lower()
+            if normalised not in supported_languages:
+                raise ValueError(
+                    f"Language '{submission_language}' is not supported by this grading "
+                    f"configuration. Supported: {', '.join(supported_languages)}"
+                )
+            language = normalised
+        else:
+            if not supported_languages:
+                raise ValueError("Grading configuration has no languages defined.")
+            language = supported_languages[0]
+
+        # Use the integer DB ID from the config response for the result payload.
+        config_db_id: int = config["id"]
+        include_feedback: bool = config.get("include_feedback", True)
+
+        exporter = CloudExporter(client, config_db_id, language, student_name)
+        self._cloud_exporter = exporter
+
+        return build_pipeline(
+            template_name=config.get("template_name"),
+            grading_criteria=config.get("criteria_config"),
+            feedback_config=config.get("feedback_config") or {},
+            setup_config=config.get("setup_config") or {},
+            include_feedback=include_feedback,
+            feedback_mode=feedback_mode,
+            export_results=True,
+            exporter=exporter,
+        )
+
+    def submit_failure_to_cloud(self, error_message: str, execution_time_ms: int = 0) -> None:
+        """
+        Attempt to submit a failure payload to the Autograder Cloud.
+
+        Should be called when grading fails *after* the pipeline was built (i.e.
+        the :class:`~autograder.steps.export_step.ExporterStep` did not run).
+        If no cloud exporter is available (e.g. config fetch itself failed) this
+        method is a safe no-op.
+
+        Args:
+            error_message: Human-readable description of the failure.
+            execution_time_ms: Elapsed time in milliseconds up to the failure.
+        """
+        if self._cloud_exporter is None:
+            logger.warning(
+                "submit_failure_to_cloud called but no cloud exporter is available; skipping."
+            )
+            return
+        try:
+            self._cloud_exporter.submit_failure(error_message, execution_time_ms)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to submit failure payload to cloud: %s", exc)
 
     def __read_path(self, configuration_path: str, file_name: str, optional=True):
         """

--- a/github_action/github_action_service.py
+++ b/github_action/github_action_service.py
@@ -39,6 +39,7 @@ class GithubActionService:
         self.repo = self.get_repository(app_token)
         self._cloud_exporter: Optional[CloudExporter] = None
         self._submission_language: Optional[Language] = None
+        self._locale: str = "en"
 
     def run_autograder(
         self, pipeline: AutograderPipeline, user_name: str, submission_files: dict
@@ -60,6 +61,7 @@ class GithubActionService:
                 assignment_id=self.app_token,
                 submission_files=submission_files,
                 language=self._submission_language,
+                locale=self._locale,
             )
 
             return pipeline.run(submission)
@@ -300,6 +302,7 @@ class GithubActionService:
         exporter = CloudExporter(client, config_db_id, language, student_name)
         self._cloud_exporter = exporter
         self._submission_language = Language(language)
+        self._locale = locale
 
         return build_pipeline(
             template_name=config.get("template_name"),

--- a/github_action/github_action_service.py
+++ b/github_action/github_action_service.py
@@ -6,6 +6,7 @@ from typing import Optional
 from autograder.autograder import build_pipeline, AutograderPipeline
 from autograder.models.dataclass.submission import Submission
 from github_action.cloud_client import CloudClient
+from sandbox_manager.models.sandbox_models import Language
 from github_action.cloud_exporter import CloudExporter
 from github_action.github_classroom_exporter import GithubClassroomExporter
 from github import Github
@@ -37,6 +38,7 @@ class GithubActionService:
         self.app_token = app_token
         self.repo = self.get_repository(app_token)
         self._cloud_exporter: Optional[CloudExporter] = None
+        self._submission_language: Optional[Language] = None
 
     def run_autograder(
         self, pipeline: AutograderPipeline, user_name: str, submission_files: dict
@@ -57,6 +59,7 @@ class GithubActionService:
                 user_id=self.github_token,
                 assignment_id=self.app_token,
                 submission_files=submission_files,
+                language=self._submission_language,
             )
 
             return pipeline.run(submission)
@@ -295,6 +298,7 @@ class GithubActionService:
 
         exporter = CloudExporter(client, config_db_id, language, student_name)
         self._cloud_exporter = exporter
+        self._submission_language = Language(language)
 
         return build_pipeline(
             template_name=config.get("template_name"),
@@ -327,7 +331,7 @@ class GithubActionService:
             return
         try:
             self._cloud_exporter.submit_failure(error_message, execution_time_ms)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
             logger.warning("Failed to submit failure payload to cloud: %s", exc)
 
     def __read_path(self, configuration_path: str, file_name: str, optional=True):

--- a/github_action/main.py
+++ b/github_action/main.py
@@ -89,6 +89,13 @@ parser.add_argument(
         "Defaults to the first language in the config when omitted."
     ),
 )
+parser.add_argument(
+    "--locale",
+    type=str,
+    required=False,
+    default="en",
+    help="Locale for feedback messages (e.g. 'en', 'pt-br'). Defaults to 'en'.",
+)
 
 
 async def main():
@@ -157,6 +164,7 @@ def __run_external_mode(args, service: GithubActionService):
         args.feedback_type,
         args.student_name,
         args.submission_language,
+        args.locale,
     )
     try:
         __retrieve_grading_score(args, service, pipeline)

--- a/github_action/main.py
+++ b/github_action/main.py
@@ -237,6 +237,12 @@ def __parser_values():
             raise ValueError(
                 "grading-config-id is required when execution-mode is 'external'."
             )
+        try:
+            args.grading_config_id = int(args.grading_config_id)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "grading-config-id must be an integer when execution-mode is 'external'."
+            ) from exc
         if not args.autograder_cloud_url:
             raise ValueError(
                 "autograder-cloud-url is required when execution-mode is 'external'."

--- a/github_action/main.py
+++ b/github_action/main.py
@@ -7,6 +7,7 @@ with the autograder workflow to process student submissions and generate feedbac
 
 import logging
 import os
+import time
 from dotenv import load_dotenv
 from argparse import ArgumentParser
 from .github_action_service import GithubActionService
@@ -52,6 +53,42 @@ parser.add_argument(
     required=False,
     help="Whether to include/generate feedback (true/false).",
 )
+parser.add_argument(
+    "--execution-mode",
+    type=str,
+    default="repo",
+    choices=["repo", "external"],
+    help="Execution mode: 'repo' (default) uses repository config; 'external' loads config from the Autograder Cloud.",
+)
+parser.add_argument(
+    "--grading-config-id",
+    type=str,
+    required=False,
+    help="Grading configuration ID from the Autograder Cloud. Required when execution-mode is 'external'.",
+)
+parser.add_argument(
+    "--autograder-cloud-url",
+    type=str,
+    required=False,
+    help="Base URL of the Autograder Cloud instance. Required when execution-mode is 'external'.",
+)
+parser.add_argument(
+    "--autograder-cloud-token",
+    type=str,
+    required=False,
+    help="Authentication token for the Autograder Cloud API. Required when execution-mode is 'external'.",
+)
+parser.add_argument(
+    "--submission-language",
+    type=str,
+    required=False,
+    default=None,
+    help=(
+        "Programming language of the student submission (e.g. 'python', 'java'). "
+        "Validated against the grading config's supported languages. "
+        "Defaults to the first language in the config when omitted."
+    ),
+)
 
 
 async def main():
@@ -76,8 +113,12 @@ async def main():
             os.environ["OPENAI_API_KEY"] = args.openai_key
 
         service = GithubActionService(args.github_token, args.app_token)
-        pipeline = __build_pipeline(args, include_feedback, service)
-        __retrieve_grading_score(args, service, pipeline)
+
+        if args.execution_mode == "external":
+            __run_external_mode(args, service)
+        else:
+            pipeline = __build_pipeline(args, include_feedback, service)
+            __retrieve_grading_score(args, service, pipeline)
 
         success_execution = True
     except ValueError as e:
@@ -89,6 +130,41 @@ async def main():
     finally:
         if not success_execution:
             raise SystemExit(1)
+
+
+def __run_external_mode(args, service: GithubActionService):
+    """
+    Execute the grading pipeline using configuration fetched from the Autograder Cloud.
+
+    If grading fails after the pipeline is built, a failure payload is submitted
+    to the cloud before re-raising the exception so the cloud records a terminal
+    state for the submission.
+
+    Args:
+        args: Parsed command-line arguments containing cloud connection parameters.
+        service (GithubActionService): The GitHub Action service instance.
+    """
+    logger.info(
+        "Running in external mode with config ID '%s' from '%s'.",
+        args.grading_config_id,
+        args.autograder_cloud_url,
+    )
+    start_time = time.time()
+    pipeline = service.autograder_pipeline_from_cloud(
+        args.grading_config_id,
+        args.autograder_cloud_url,
+        args.autograder_cloud_token,
+        args.feedback_type,
+        args.student_name,
+        args.submission_language,
+    )
+    try:
+        __retrieve_grading_score(args, service, pipeline)
+    except Exception as exc:
+        execution_time_ms = int((time.time() - start_time) * 1000)
+        logger.error("Grading failed in external mode; submitting failure payload: %s", exc)
+        service.submit_failure_to_cloud(str(exc), execution_time_ms)
+        raise
 
 
 def __retrieve_grading_score(
@@ -155,6 +231,20 @@ def __parser_values():
         raise ValueError(
             "OpenAI API key is required for AI feedback mode in GitHub Actions. Please configure OPENAI_API_KEY as a secret."
         )
+
+    if args.execution_mode == "external":
+        if not args.grading_config_id:
+            raise ValueError(
+                "grading-config-id is required when execution-mode is 'external'."
+            )
+        if not args.autograder_cloud_url:
+            raise ValueError(
+                "autograder-cloud-url is required when execution-mode is 'external'."
+            )
+        if not args.autograder_cloud_token:
+            raise ValueError(
+                "autograder-cloud-token is required when execution-mode is 'external'."
+            )
 
     return args
 

--- a/tests/unit/github_action/test_cloud_client.py
+++ b/tests/unit/github_action/test_cloud_client.py
@@ -1,0 +1,374 @@
+# pylint: disable=protected-access
+"""Unit tests for github_action.cloud_client.CloudClient."""
+
+import json
+import urllib.error
+import urllib.request
+from io import BytesIO
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from github_action.cloud_client import (
+    CloudClient,
+    CloudClientError,
+    CloudConnectionError,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_client(
+    cloud_url="https://cloud.example.com",
+    cloud_token="secret-token",
+    max_retries=3,
+):
+    return CloudClient(cloud_url, cloud_token, max_retries=max_retries)
+
+def _mock_response(body: dict | str, status: int = 200):
+    """Return a mock context-manager that urlopen can return."""
+    if isinstance(body, dict):
+        raw = json.dumps(body).encode()
+    else:
+        raw = body.encode()
+
+    cm = MagicMock()
+    cm.__enter__ = MagicMock(return_value=cm)
+    cm.__exit__ = MagicMock(return_value=False)
+    cm.read.return_value = raw
+    return cm
+
+def _http_error(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        url="https://cloud.example.com/api/v1/grading-configs/cfg-1",
+        code=code,
+        msg=f"HTTP {code}",
+        hdrs=None,
+        fp=None,
+    )
+
+# ---------------------------------------------------------------------------
+# CloudClient.__init__
+# ---------------------------------------------------------------------------
+
+class TestCloudClientInit:
+    def test_trailing_slash_stripped_from_base_url(self):
+        """Asserts base URL trailing slashes are normalised."""
+        client = CloudClient("https://cloud.example.com///", "tok")
+        assert client._base_url == "https://cloud.example.com"
+
+    def test_default_timeout_and_retry_values(self):
+        """Asserts default timeouts and max_retries match module constants."""
+        client = CloudClient("https://cloud.example.com", "tok")
+        assert client.connect_timeout == 10.0
+        assert client.read_timeout == 30.0
+        assert client.max_retries == 3
+
+    def test_custom_timeouts_stored(self):
+        """Asserts custom timeouts are stored on the instance."""
+        client = CloudClient(
+            "https://cloud.example.com",
+            "tok",
+            connect_timeout=5.0,
+            read_timeout=60.0,
+        )
+        assert client.connect_timeout == 5.0
+        assert client.read_timeout == 60.0
+
+# ---------------------------------------------------------------------------
+# get_grading_config
+# ---------------------------------------------------------------------------
+
+class TestGetGradingConfig:
+    def test_calls_correct_url(self):
+        """Asserts the correct endpoint URL is called for a given config ID."""
+        client = _make_client()
+        mock_resp = _mock_response({"template_name": "python"})
+
+        captured_req = []
+
+        def fake_urlopen(req, timeout=None):
+            captured_req.append(req)
+            return mock_resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen), patch(
+            "time.sleep"
+        ):
+            client.get_grading_config("cfg-42")
+
+        assert len(captured_req) == 1
+        assert captured_req[0].full_url == "https://cloud.example.com/api/v1/configs/id/cfg-42"
+
+    def test_returns_parsed_json(self):
+        """Asserts the response body is parsed as JSON and returned."""
+        client = _make_client()
+        config = {"template_name": "python", "criteria": {"base": {}}}
+        mock_resp = _mock_response(config)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp), patch(
+            "time.sleep"
+        ):
+            result = client.get_grading_config("cfg-1")
+
+        assert result == config
+
+    def test_authorization_header_sent(self):
+        """Asserts the Bearer token is included in the Authorization header."""
+        client = CloudClient("https://cloud.example.com", "my-secret")
+        mock_resp = _mock_response({})
+        captured = []
+
+        def fake_urlopen(req, timeout=None):
+            captured.append(req)
+            return mock_resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen), patch(
+            "time.sleep"
+        ):
+            client.get_grading_config("cfg-1")
+
+        assert captured[0].get_header("Authorization") == "Bearer my-secret"
+
+    def test_token_not_in_error_message_on_404(self):
+        """Asserts the bearer token is not leaked in 4xx error messages."""
+        client = CloudClient("https://cloud.example.com", "super-secret-token")
+
+        with patch("urllib.request.urlopen", side_effect=_http_error(404)), patch(
+            "time.sleep"
+        ):
+            with pytest.raises(CloudClientError) as exc_info:
+                client.get_grading_config("cfg-missing")
+
+        assert "super-secret-token" not in str(exc_info.value)
+
+# ---------------------------------------------------------------------------
+# submit_external_result
+# ---------------------------------------------------------------------------
+
+class TestSubmitExternalResult:
+    def test_calls_correct_url_with_post(self):
+        """Asserts POST is used and the correct URL is targeted."""
+        client = _make_client()
+        mock_resp = _mock_response({})
+        captured = []
+
+        def fake_urlopen(req, timeout=None):
+            captured.append(req)
+            return mock_resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen), patch(
+            "time.sleep"
+        ):
+            client.submit_external_result({"score": 90.0})
+
+        req = captured[0]
+        assert req.full_url == "https://cloud.example.com/api/v1/submissions/external-results"
+        assert req.method == "POST"
+
+    def test_payload_serialised_as_json(self):
+        """Asserts the payload dict is sent as JSON in the request body."""
+        client = _make_client()
+        mock_resp = _mock_response({})
+        captured = []
+
+        def fake_urlopen(req, timeout=None):
+            captured.append(req)
+            return mock_resp
+
+        payload = {"score": 75.5, "status": "success"}
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen), patch(
+            "time.sleep"
+        ):
+            client.submit_external_result(payload)
+
+        sent_body = json.loads(captured[0].data)
+        assert sent_body == payload
+
+    def test_returns_empty_dict_for_empty_response(self):
+        """Asserts an empty response body returns an empty dict."""
+        client = _make_client()
+        mock_resp = _mock_response("")
+
+        with patch("urllib.request.urlopen", return_value=mock_resp), patch(
+            "time.sleep"
+        ):
+            result = client.submit_external_result({"score": 0.0})
+
+        assert result == {}
+
+# ---------------------------------------------------------------------------
+# Error handling — 4xx (CloudClientError, no retry)
+# ---------------------------------------------------------------------------
+
+class TestFourXxErrors:
+    @pytest.mark.parametrize("code", [400, 401, 403, 404, 422])
+    def test_4xx_raises_cloud_client_error_immediately(self, code):
+        """Asserts CloudClientError is raised without retrying for 4xx responses."""
+        client = _make_client(max_retries=3)
+
+        with patch(
+            "urllib.request.urlopen", side_effect=_http_error(code)
+        ) as mock_open, patch("time.sleep") as mock_sleep:
+            with pytest.raises(CloudClientError) as exc_info:
+                client.get_grading_config("cfg-1")
+
+        # urlopen called exactly once — no retries
+        mock_open.assert_called_once()
+        mock_sleep.assert_not_called()
+        assert exc_info.value.status_code == code
+
+    def test_4xx_error_message_is_actionable(self):
+        """Asserts the 4xx error message instructs the user to check their configuration."""
+        client = _make_client()
+
+        with patch("urllib.request.urlopen", side_effect=_http_error(404)), patch(
+            "time.sleep"
+        ):
+            with pytest.raises(CloudClientError) as exc_info:
+                client.get_grading_config("cfg-bad")
+
+        msg = str(exc_info.value)
+        assert "404" in msg
+        assert "configuration ID" in msg or "config" in msg.lower()
+
+# ---------------------------------------------------------------------------
+# Error handling — 5xx (retry, then CloudConnectionError)
+# ---------------------------------------------------------------------------
+
+class TestFiveXxRetry:
+    def test_5xx_retried_up_to_max_retries(self):
+        """Asserts urlopen is called max_retries+1 times on persistent 5xx."""
+        client = _make_client(max_retries=2)
+
+        with patch(
+            "urllib.request.urlopen", side_effect=_http_error(503)
+        ) as mock_open, patch("time.sleep"):
+            with pytest.raises(CloudConnectionError):
+                client.get_grading_config("cfg-1")
+
+        assert mock_open.call_count == 3  # 1 initial + 2 retries
+
+    def test_5xx_succeeds_on_second_attempt(self):
+        """Asserts a successful response after one 5xx failure returns the payload."""
+        client = _make_client(max_retries=2)
+        config = {"template_name": "api"}
+        mock_resp = _mock_response(config)
+
+        call_count = [0]
+
+        def flaky_urlopen(req, timeout=None):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise _http_error(500)
+            return mock_resp
+
+        with patch("urllib.request.urlopen", side_effect=flaky_urlopen), patch(
+            "time.sleep"
+        ):
+            result = client.get_grading_config("cfg-1")
+
+        assert result == config
+        assert call_count[0] == 2
+
+    def test_5xx_raises_connection_error_after_exhausting_retries(self):
+        """Asserts CloudConnectionError is raised after all retries are exhausted."""
+        client = _make_client(max_retries=1)
+
+        with patch("urllib.request.urlopen", side_effect=_http_error(500)), patch(
+            "time.sleep"
+        ):
+            with pytest.raises(CloudConnectionError):
+                client.get_grading_config("cfg-1")
+
+    def test_exponential_backoff_delays_used(self):
+        """Asserts time.sleep is called with exponentially increasing delays."""
+        client = _make_client(max_retries=3)
+        sleep_calls = []
+
+        with patch(
+            "urllib.request.urlopen", side_effect=_http_error(502)
+        ), patch("time.sleep", side_effect=lambda s: sleep_calls.append(s)):
+            with pytest.raises(CloudConnectionError):
+                client.get_grading_config("cfg-1")
+
+        # 3 retries → 3 sleep calls with delays 1, 2, 4
+        assert sleep_calls == [1.0, 2.0, 4.0]
+
+# ---------------------------------------------------------------------------
+# Error handling — network errors (URLError)
+# ---------------------------------------------------------------------------
+
+class TestNetworkErrors:
+    def test_url_error_retried(self):
+        """Asserts network errors (URLError) are retried like 5xx responses."""
+        client = _make_client(max_retries=2)
+        network_err = urllib.error.URLError("Connection refused")
+
+        with patch(
+            "urllib.request.urlopen", side_effect=network_err
+        ) as mock_open, patch("time.sleep"):
+            with pytest.raises(CloudConnectionError):
+                client.get_grading_config("cfg-1")
+
+        assert mock_open.call_count == 3
+
+    def test_url_error_error_message_does_not_leak_token(self):
+        """Asserts the cloud token is not present in CloudConnectionError messages."""
+        client = CloudClient("https://cloud.example.com", "leak-me-not", max_retries=0)
+        network_err = urllib.error.URLError("timeout")
+
+        with patch("urllib.request.urlopen", side_effect=network_err), patch(
+            "time.sleep"
+        ):
+            with pytest.raises(CloudConnectionError) as exc_info:
+                client.get_grading_config("cfg-1")
+
+        assert "leak-me-not" not in str(exc_info.value)
+
+    def test_succeeds_after_transient_network_error(self):
+        """Asserts success is returned after a single transient URLError."""
+        client = _make_client(max_retries=2)
+        config = {"template_name": "html"}
+        mock_resp = _mock_response(config)
+        call_count = [0]
+
+        def flaky(req, timeout=None):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise urllib.error.URLError("temporary")
+            return mock_resp
+
+        with patch("urllib.request.urlopen", side_effect=flaky), patch("time.sleep"):
+            result = client.get_grading_config("cfg-1")
+
+        assert result == config
+
+# ---------------------------------------------------------------------------
+# JSON parsing
+# ---------------------------------------------------------------------------
+
+class TestJsonParsing:
+    def test_invalid_json_raises_connection_error(self):
+        """Asserts a malformed JSON response raises CloudConnectionError."""
+        client = _make_client()
+        mock_resp = _mock_response("not-json")
+
+        with patch("urllib.request.urlopen", return_value=mock_resp), patch(
+            "time.sleep"
+        ):
+            with pytest.raises(CloudConnectionError, match="invalid JSON"):
+                client.get_grading_config("cfg-1")
+
+    def test_empty_response_returns_empty_dict(self):
+        """Asserts an empty response body returns {}."""
+        client = _make_client()
+        mock_resp = _mock_response("   ")
+
+        with patch("urllib.request.urlopen", return_value=mock_resp), patch(
+            "time.sleep"
+        ):
+            result = client.get_grading_config("cfg-1")
+
+        assert result == {}

--- a/tests/unit/github_action/test_cloud_client.py
+++ b/tests/unit/github_action/test_cloud_client.py
@@ -95,10 +95,10 @@ class TestGetGradingConfig:
         with patch("urllib.request.urlopen", side_effect=fake_urlopen), patch(
             "time.sleep"
         ):
-            client.get_grading_config("cfg-42")
+            client.get_grading_config(42)
 
         assert len(captured_req) == 1
-        assert captured_req[0].full_url == "https://cloud.example.com/api/v1/configs/id/cfg-42"
+        assert captured_req[0].full_url == "https://cloud.example.com/api/v1/configs/id/42"
 
     def test_returns_parsed_json(self):
         """Asserts the response body is parsed as JSON and returned."""

--- a/tests/unit/github_action/test_cloud_exporter.py
+++ b/tests/unit/github_action/test_cloud_exporter.py
@@ -1,0 +1,421 @@
+# pylint: disable=protected-access
+"""Unit tests for github_action.cloud_exporter.CloudExporter."""
+
+import os
+import time
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from github_action.cloud_client import CloudClient
+from github_action.cloud_exporter import CloudExporter
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_client() -> CloudClient:
+    client = MagicMock(spec=CloudClient)
+    client.submit_external_result.return_value = {}
+    return client
+
+def _make_exporter(
+    config_id: int = 42,
+    language: str = "python",
+    student_name: str = "student1",
+) -> tuple[CloudExporter, CloudClient]:
+    client = _make_client()
+    exporter = CloudExporter(client, config_id, language, student_name)
+    return exporter, client
+
+def _make_pipeline_exec(
+    *,
+    user_id: str = "student1",
+    final_score: float = 85.0,
+    feedback: Optional[str] = "Good job!",
+    status_value: str = "success",
+    start_time: Optional[float] = None,
+    include_focus: bool = True,
+    include_result_tree: bool = True,
+) -> MagicMock:
+    """Build a minimal mock PipelineExecution for exporter tests."""
+    pe = MagicMock()
+    pe.submission.user_id = user_id
+    pe.status.value = status_value
+    pe.start_time = start_time if start_time is not None else time.time() - 1.5
+
+    # Grade step
+    grade_result = MagicMock()
+    grade_result.final_score = final_score
+    pe.get_grade_step_result.return_value = grade_result
+
+    # Feedback
+    pe.get_feedback.return_value = feedback
+
+    # Result tree
+    if include_result_tree:
+        result_tree = MagicMock()
+        result_tree.to_dict.return_value = {"final_score": final_score, "tree": {}}
+        pe.get_result_tree.return_value = result_tree
+    else:
+        pe.get_result_tree.side_effect = ValueError("No grade result")
+
+    # Focus
+    if include_focus:
+        focus = MagicMock()
+        focus.to_dict.return_value = {"base": [], "penalty": None, "bonus": None}
+        pe.get_focus.return_value = focus
+    else:
+        pe.get_focus.side_effect = ValueError("No focus")
+
+    return pe
+
+# GitHub env vars injected by every test in this module
+_GITHUB_ENV = {
+    "GITHUB_REPOSITORY": "owner/repo",
+    "GITHUB_SHA": "abc123def456",
+    "GITHUB_RUN_ID": "9876543210",
+    "GITHUB_ACTOR": "student1",
+    "GITHUB_REF": "refs/heads/main",
+}
+
+# ---------------------------------------------------------------------------
+# export_with_context — payload structure
+# ---------------------------------------------------------------------------
+
+class TestExportWithContextPayloadStructure:
+    def test_submits_to_cloud_client(self):
+        """Asserts submit_external_result is called once."""
+        exporter, client = _make_exporter()
+        pe = _make_pipeline_exec()
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.export_with_context(pe)
+
+        client.submit_external_result.assert_called_once()
+
+    def test_score_in_payload(self):
+        """Asserts the final score is present in the submitted payload."""
+        exporter, client = _make_exporter()
+        pe = _make_pipeline_exec(final_score=92.5)
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.export_with_context(pe)
+
+        payload = client.submit_external_result.call_args[0][0]
+        assert payload["final_score"] == 92.5
+
+    def test_feedback_in_payload(self):
+        """Asserts the feedback string is present in the submitted payload."""
+        exporter, client = _make_exporter()
+        pe = _make_pipeline_exec(feedback="Excellent work!")
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.export_with_context(pe)
+
+        payload = client.submit_external_result.call_args[0][0]
+        assert payload["feedback"] == "Excellent work!"
+
+    def test_none_feedback_in_payload(self):
+        """Asserts None feedback is preserved in the payload."""
+        exporter, client = _make_exporter()
+        pe = _make_pipeline_exec(feedback=None)
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.export_with_context(pe)
+
+        payload = client.submit_external_result.call_args[0][0]
+        assert payload["feedback"] is None
+
+    def test_status_in_payload(self):
+        """Asserts the payload status is 'completed' when grading succeeds."""
+        exporter, client = _make_exporter()
+        pe = _make_pipeline_exec(status_value="success")
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.export_with_context(pe)
+
+        payload = client.submit_external_result.call_args[0][0]
+        assert payload["status"] == "completed"
+
+    def test_grading_config_id_in_payload(self):
+        """Asserts the integer grading config ID is included for server-side correlation."""
+        exporter, client = _make_exporter(config_id=99)
+        pe = _make_pipeline_exec()
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.export_with_context(pe)
+
+        payload = client.submit_external_result.call_args[0][0]
+        assert payload["grading_config_id"] == 99
+        assert isinstance(payload["grading_config_id"], int)
+
+    def test_result_tree_serialised_in_payload(self):
+        """Asserts the result tree to_dict() output is included in the payload."""
+        exporter, client = _make_exporter()
+        pe = _make_pipeline_exec(include_result_tree=True)
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.export_with_context(pe)
+
+        payload = client.submit_external_result.call_args[0][0]
+        assert payload["result_tree"] is not None
+        assert "final_score" in payload["result_tree"]
+
+    def test_focus_serialised_in_payload(self):
+        """Asserts the focus dict is included in the payload."""
+        exporter, client = _make_exporter()
+        pe = _make_pipeline_exec(include_focus=True)
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.export_with_context(pe)
+
+        payload = client.submit_external_result.call_args[0][0]
+        assert payload["focus"] is not None
+        assert "base" in payload["focus"]
+
+    def test_execution_time_ms_positive(self):
+        """Asserts execution_time_ms is a positive integer."""
+        exporter, client = _make_exporter()
+        pe = _make_pipeline_exec(start_time=time.time() - 2.0)
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.export_with_context(pe)
+
+        payload = client.submit_external_result.call_args[0][0]
+        assert isinstance(payload["execution_time_ms"], int)
+        assert payload["execution_time_ms"] > 0
+
+    def test_submission_user_id_in_payload(self):
+        """Asserts external_user_id and username are set from the student_name."""
+        exporter, client = _make_exporter(student_name="alice")
+        pe = _make_pipeline_exec(user_id="alice")
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.export_with_context(pe)
+
+        payload = client.submit_external_result.call_args[0][0]
+        assert payload["external_user_id"] == "alice"
+        assert payload["username"] == "alice"
+
+    def test_error_message_none_on_success(self):
+        """Asserts error_message is None when the pipeline succeeds."""
+        exporter, client = _make_exporter()
+        pe = _make_pipeline_exec()
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.export_with_context(pe)
+
+        payload = client.submit_external_result.call_args[0][0]
+        assert payload["error_message"] is None
+
+# ---------------------------------------------------------------------------
+# export_with_context — GitHub context mapping
+# ---------------------------------------------------------------------------
+
+class TestGitHubContextMapping:
+    def test_all_github_env_vars_present_in_payload(self):
+        """Asserts all five GitHub context fields are present in submission_metadata."""
+        exporter, client = _make_exporter()
+        pe = _make_pipeline_exec()
+
+        with patch.dict(os.environ, _GITHUB_ENV, clear=False):
+            exporter.export_with_context(pe)
+
+        github_ctx = client.submit_external_result.call_args[0][0]["submission_metadata"]
+        assert github_ctx["repository"] == "owner/repo"
+        assert github_ctx["commit_sha"] == "abc123def456"
+        assert github_ctx["run_id"] == "9876543210"
+        assert github_ctx["actor"] == "student1"
+        assert github_ctx["ref"] == "refs/heads/main"
+
+    def test_missing_github_env_vars_default_to_none(self):
+        """Asserts missing GitHub env vars produce None values (not KeyError)."""
+        exporter, client = _make_exporter()
+        pe = _make_pipeline_exec()
+
+        # Remove all GitHub env vars
+        clean_env = {
+            k: v
+            for k, v in os.environ.items()
+            if not k.startswith("GITHUB_")
+        }
+        with patch.dict(os.environ, clean_env, clear=True):
+            exporter.export_with_context(pe)
+
+        github_ctx = client.submit_external_result.call_args[0][0]["submission_metadata"]
+        assert github_ctx["repository"] is None
+        assert github_ctx["commit_sha"] is None
+        assert github_ctx["run_id"] is None
+        assert github_ctx["actor"] is None
+        assert github_ctx["ref"] is None
+
+# ---------------------------------------------------------------------------
+# export_with_context — graceful degradation
+# ---------------------------------------------------------------------------
+
+class TestGracefulDegradation:
+    def test_result_tree_none_when_grade_step_unavailable(self):
+        """Asserts result_tree is None in the payload when get_result_tree raises."""
+        exporter, client = _make_exporter()
+        pe = _make_pipeline_exec(include_result_tree=False)
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.export_with_context(pe)
+
+        payload = client.submit_external_result.call_args[0][0]
+        assert payload["result_tree"] is None
+
+    def test_focus_none_when_focus_unavailable(self):
+        """Asserts focus is None in the payload when get_focus raises."""
+        exporter, client = _make_exporter()
+        pe = _make_pipeline_exec(include_focus=False)
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.export_with_context(pe)
+
+        payload = client.submit_external_result.call_args[0][0]
+        assert payload["focus"] is None
+
+    def test_score_zero_and_error_message_set_when_grade_result_raises(self):
+        """Asserts score defaults to 0 and error_message is set when get_grade_step_result raises."""
+        exporter, client = _make_exporter()
+        pe = _make_pipeline_exec()
+        pe.get_grade_step_result.side_effect = ValueError("Grade step not run")
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.export_with_context(pe)
+
+        payload = client.submit_external_result.call_args[0][0]
+        assert payload["final_score"] == 0.0
+        assert payload["error_message"] is not None
+        assert "Grade step not run" in payload["error_message"]
+        assert payload["status"] == "failed"
+
+# ---------------------------------------------------------------------------
+# export (minimal / fallback path)
+# ---------------------------------------------------------------------------
+
+class TestMinimalExport:
+    def test_submits_score_and_feedback(self):
+        """Asserts minimal export passes score and feedback to the cloud client."""
+        exporter, client = _make_exporter()
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.export("student1", 70.0, "Decent effort.")
+
+        payload = client.submit_external_result.call_args[0][0]
+        assert payload["final_score"] == 70.0
+        assert payload["feedback"] == "Decent effort."
+
+    def test_result_tree_and_focus_are_none(self):
+        """Asserts result_tree and focus are None in the minimal payload."""
+        exporter, client = _make_exporter()
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.export("student1", 50.0)
+
+        payload = client.submit_external_result.call_args[0][0]
+        assert payload["result_tree"] is None
+        assert payload["focus"] is None
+
+    def test_execution_time_ms_is_zero(self):
+        """Asserts execution_time_ms is 0 in the minimal payload (no pipeline context)."""
+        exporter, client = _make_exporter()
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.export("student1", 50.0)
+
+        payload = client.submit_external_result.call_args[0][0]
+        assert payload["execution_time_ms"] == 0
+
+    def test_config_id_present(self):
+        """Asserts the integer grading config ID is included even in the minimal payload."""
+        exporter, client = _make_exporter(config_id=42)
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.export("student1", 88.0)
+
+        payload = client.submit_external_result.call_args[0][0]
+        assert payload["grading_config_id"] == 42
+
+    def test_none_feedback_handled(self):
+        """Asserts None feedback is preserved in the minimal payload."""
+        exporter, client = _make_exporter()
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.export("student1", 80.0, None)
+
+        payload = client.submit_external_result.call_args[0][0]
+        assert payload["feedback"] is None
+
+# ---------------------------------------------------------------------------
+# Exporter ABC integration
+# ---------------------------------------------------------------------------
+
+class TestExporterAbcIntegration:
+    def test_is_instance_of_exporter_abc(self):
+        """Asserts CloudExporter satisfies the Exporter ABC."""
+        from autograder.models.abstract.exporter import Exporter
+
+        exporter, _ = _make_exporter()
+        assert isinstance(exporter, Exporter)
+
+    def test_export_with_context_default_calls_export_on_base_exporter(self):
+        """Asserts the default export_with_context on Exporter ABC delegates to export()."""
+        from autograder.models.abstract.exporter import Exporter
+
+        class MinimalExporter(Exporter):
+            def __init__(self):
+                self.calls = []
+
+            def export(self, user_id, score, feedback=None):
+                self.calls.append((user_id, score, feedback))
+
+        minimal = MinimalExporter()
+        pe = _make_pipeline_exec(user_id="bob", final_score=55.0, feedback="Try again.")
+        minimal.export_with_context(pe)
+
+        assert minimal.calls == [("bob", 55.0, "Try again.")]
+
+# ---------------------------------------------------------------------------
+# submit_failure
+# ---------------------------------------------------------------------------
+
+class TestSubmitFailure:
+    def test_submit_failure_calls_client(self):
+        """Asserts submit_failure calls submit_external_result once."""
+        exporter, client = _make_exporter(config_id=7, language="java", student_name="alice")
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.submit_failure("sandbox timeout", 5000)
+
+        client.submit_external_result.assert_called_once()
+
+    def test_submit_failure_payload_fields(self):
+        """Asserts submit_failure builds the correct payload fields."""
+        exporter, client = _make_exporter(config_id=7, language="java", student_name="alice")
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.submit_failure("sandbox timeout", 5000)
+
+        payload = client.submit_external_result.call_args[0][0]
+        assert payload["grading_config_id"] == 7
+        assert payload["external_user_id"] == "alice"
+        assert payload["username"] == "alice"
+        assert payload["language"] == "java"
+        assert payload["status"] == "failed"
+        assert payload["final_score"] == 0.0
+        assert payload["execution_time_ms"] == 5000
+        assert payload["error_message"] == "sandbox timeout"
+
+    def test_submit_failure_default_execution_time(self):
+        """Asserts submit_failure defaults execution_time_ms to 0."""
+        exporter, client = _make_exporter()
+
+        with patch.dict(os.environ, _GITHUB_ENV):
+            exporter.submit_failure("some error")
+
+        payload = client.submit_external_result.call_args[0][0]
+        assert payload["execution_time_ms"] == 0

--- a/tests/unit/github_action/test_github_action_service.py
+++ b/tests/unit/github_action/test_github_action_service.py
@@ -527,7 +527,7 @@ class TestAutograderPipelineFromCloud:
             mock_build.return_value = mock_pipeline
 
             result = service.autograder_pipeline_from_cloud(
-                grading_config_id="cfg-7",
+                grading_config_id="7",
                 cloud_url="https://cloud.example.com",
                 cloud_token="tok",
                 feedback_mode="default",
@@ -546,7 +546,7 @@ class TestAutograderPipelineFromCloud:
         """Asserts CloudClient.get_grading_config is called with the provided config ID."""
         service = _make_service()
         _, client, *_ = self._call(service)
-        client.get_grading_config.assert_called_once_with("cfg-7")
+        client.get_grading_config.assert_called_once_with("7")
 
     def test_cloud_exporter_receives_int_config_id(self):
         """Asserts CloudExporter is constructed with the integer DB ID from the config response."""
@@ -600,7 +600,7 @@ class TestAutograderPipelineFromCloud:
 
             with pytest.raises(ValueError, match="not supported"):
                 service.autograder_pipeline_from_cloud(
-                    grading_config_id="cfg-7",
+                    grading_config_id="7",
                     cloud_url="https://cloud.example.com",
                     cloud_token="tok",
                     feedback_mode="default",
@@ -621,7 +621,7 @@ class TestAutograderPipelineFromCloud:
 
             with pytest.raises(ValueError, match="no languages"):
                 service.autograder_pipeline_from_cloud(
-                    grading_config_id="cfg-7",
+                    grading_config_id="7",
                     cloud_url="https://cloud.example.com",
                     cloud_token="tok",
                     feedback_mode="default",

--- a/tests/unit/github_action/test_github_action_service.py
+++ b/tests/unit/github_action/test_github_action_service.py
@@ -100,6 +100,8 @@ class TestRunAutograder:
             user_id="gh-tok",
             assignment_id="app-tok",
             submission_files=submission_files,
+            language=None,
+            locale="en",
         )
 
     def test_wraps_exception_on_pipeline_failure(self):

--- a/tests/unit/github_action/test_github_action_service.py
+++ b/tests/unit/github_action/test_github_action_service.py
@@ -9,11 +9,9 @@ from github.GithubException import UnknownObjectException
 
 from github_action.github_action_service import GithubActionService
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
 
 def _make_service(github_token="gh-token", app_token="app-token", repo="owner/repo"):
     """Create a GithubActionService with get_repository mocked out."""
@@ -23,7 +21,6 @@ def _make_service(github_token="gh-token", app_token="app-token", repo="owner/re
         mock_github.return_value.get_repo.return_value = MagicMock()
         service = GithubActionService(github_token, app_token)
     return service
-
 
 class TestGetRepository:
     """
@@ -67,7 +64,6 @@ class TestGetRepository:
 
         assert service.github_token == "my-gh-token"
         assert service.app_token == "my-app-token"
-
 
 class TestRunAutograder:
     """
@@ -114,7 +110,6 @@ class TestRunAutograder:
 
         with pytest.raises(Exception, match="Error running autograder"):
             service.run_autograder(mock_pipeline, "student1", {})
-
 
 class TestExportResults:
     """
@@ -174,7 +169,6 @@ class TestExportResults:
 
         mock_commit.assert_not_called()
         mock_notify.assert_called_once_with(0.0)
-
 
 class TestNotifyClassroom:
     """
@@ -283,7 +277,6 @@ class TestNotifyClassroom:
 
         mock_check_run.edit.assert_called_once()
 
-
 class TestFindCheckSuite:
     """
     __find_check_suite
@@ -347,7 +340,6 @@ class TestFindCheckSuite:
         with pytest.raises(Exception, match="Check run not found"):
             self._call_find(service, mock_repo, workflow_run)
 
-
 class TestCommitFeedback:
     """
     __commit_feedback()
@@ -408,7 +400,6 @@ class TestCommitFeedback:
             content="feedback content",
             sha="sha-first",
         )
-
 
 class TestAutograderPipeline:
     """
@@ -497,3 +488,191 @@ class TestAutograderPipeline:
         ), patch("builtins.open", mock_open(read_data="{}")):
             with pytest.raises(FileNotFoundError, match="setup.json"):
                 service.autograder_pipeline("python", False, "default")
+
+# ---------------------------------------------------------------------------
+# Cloud pipeline / external mode
+# ---------------------------------------------------------------------------
+
+_CLOUD_CONFIG = {
+    "id": 7,
+    "template_name": "input_output",
+    "criteria_config": {"base": {"tests": ["test_a"]}},
+    "languages": ["python", "java"],
+    "setup_config": {"required_files": ["main.py"]},
+    "feedback_config": {"show_score": True},
+    "include_feedback": True,
+}
+
+class TestAutograderPipelineFromCloud:
+    """
+    autograder_pipeline_from_cloud()
+    """
+
+    def _call(self, service, *, config=None, language=None):
+        with patch(
+            "github_action.github_action_service.CloudClient"
+        ) as mock_client_cls, patch(
+            "github_action.github_action_service.CloudExporter"
+        ) as mock_exporter_cls, patch(
+            "github_action.github_action_service.build_pipeline"
+        ) as mock_build:
+            mock_client = MagicMock()
+            mock_client.get_grading_config.return_value = config or _CLOUD_CONFIG
+            mock_client_cls.return_value = mock_client
+
+            mock_exporter = MagicMock()
+            mock_exporter_cls.return_value = mock_exporter
+
+            mock_pipeline = MagicMock()
+            mock_build.return_value = mock_pipeline
+
+            result = service.autograder_pipeline_from_cloud(
+                grading_config_id="cfg-7",
+                cloud_url="https://cloud.example.com",
+                cloud_token="tok",
+                feedback_mode="default",
+                student_name="alice",
+                submission_language=language,
+            )
+            return result, mock_client, mock_exporter_cls, mock_build
+
+    def test_returns_pipeline(self):
+        """Asserts a pipeline object is returned."""
+        service = _make_service()
+        pipeline, *_ = self._call(service)
+        assert pipeline is not None
+
+    def test_calls_get_grading_config_with_correct_id(self):
+        """Asserts CloudClient.get_grading_config is called with the provided config ID."""
+        service = _make_service()
+        _, client, *_ = self._call(service)
+        client.get_grading_config.assert_called_once_with("cfg-7")
+
+    def test_cloud_exporter_receives_int_config_id(self):
+        """Asserts CloudExporter is constructed with the integer DB ID from the config response."""
+        service = _make_service()
+        _, _, exporter_cls, _ = self._call(service)
+        assert exporter_cls.call_args[0][1] == 7  # config["id"]
+
+    def test_cloud_exporter_receives_language(self):
+        """Asserts CloudExporter is constructed with the resolved language."""
+        service = _make_service()
+        _, _, exporter_cls, _ = self._call(service, language="java")
+        assert exporter_cls.call_args[0][2] == "java"
+
+    def test_cloud_exporter_receives_student_name(self):
+        """Asserts CloudExporter is constructed with the student name."""
+        service = _make_service()
+        _, _, exporter_cls, _ = self._call(service)
+        assert exporter_cls.call_args[0][3] == "alice"
+
+    def test_language_defaults_to_first_in_config(self):
+        """Asserts the first config language is used when submission_language is None."""
+        service = _make_service()
+        _, _, exporter_cls, _ = self._call(service, language=None)
+        # _CLOUD_CONFIG["languages"][0] == "python"
+        assert exporter_cls.call_args[0][2] == "python"
+
+    def test_include_feedback_from_config(self):
+        """Asserts include_feedback is taken from the fetched config, not the args."""
+        service = _make_service()
+        config_no_feedback = {**_CLOUD_CONFIG, "include_feedback": False}
+        _, _, _, build = self._call(service, config=config_no_feedback)
+        kwargs = build.call_args[1]
+        assert kwargs["include_feedback"] is False
+
+    def test_criteria_config_key_used(self):
+        """Asserts build_pipeline receives grading_criteria from criteria_config key."""
+        service = _make_service()
+        _, _, _, build = self._call(service)
+        kwargs = build.call_args[1]
+        assert kwargs["grading_criteria"] == _CLOUD_CONFIG["criteria_config"]
+
+    def test_invalid_language_raises_value_error(self):
+        """Asserts ValueError is raised when submission_language is not in config languages."""
+        service = _make_service()
+        with patch(
+            "github_action.github_action_service.CloudClient"
+        ) as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.get_grading_config.return_value = _CLOUD_CONFIG
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(ValueError, match="not supported"):
+                service.autograder_pipeline_from_cloud(
+                    grading_config_id="cfg-7",
+                    cloud_url="https://cloud.example.com",
+                    cloud_token="tok",
+                    feedback_mode="default",
+                    student_name="alice",
+                    submission_language="ruby",  # not in ["python", "java"]
+                )
+
+    def test_empty_languages_list_raises_value_error(self):
+        """Asserts ValueError is raised when config has no languages and none is specified."""
+        service = _make_service()
+        config_empty_langs = {**_CLOUD_CONFIG, "languages": []}
+        with patch(
+            "github_action.github_action_service.CloudClient"
+        ) as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.get_grading_config.return_value = config_empty_langs
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(ValueError, match="no languages"):
+                service.autograder_pipeline_from_cloud(
+                    grading_config_id="cfg-7",
+                    cloud_url="https://cloud.example.com",
+                    cloud_token="tok",
+                    feedback_mode="default",
+                    student_name="alice",
+                    submission_language=None,
+                )
+
+    def test_cloud_exporter_stored_on_service(self):
+        """Asserts _cloud_exporter is set on the service after a successful call."""
+        service = _make_service()
+        self._call(service)
+        assert service._cloud_exporter is not None
+
+class TestSubmitFailureToCloud:
+    """
+    submit_failure_to_cloud()
+    """
+
+    def test_calls_submit_failure_on_exporter(self):
+        """Asserts submit_failure is called on the cloud exporter."""
+        service = _make_service()
+        mock_exporter = MagicMock()
+        service._cloud_exporter = mock_exporter
+
+        service.submit_failure_to_cloud("pipeline crashed", 3000)
+
+        mock_exporter.submit_failure.assert_called_once_with("pipeline crashed", 3000)
+
+    def test_noop_when_no_cloud_exporter(self):
+        """Asserts submit_failure_to_cloud is a safe no-op when no cloud exporter is set."""
+        service = _make_service()
+        assert service._cloud_exporter is None
+        # must not raise
+        service.submit_failure_to_cloud("ignored error")
+
+    def test_swallows_exception_from_submit_failure(self):
+        """Asserts exceptions raised by submit_failure are swallowed (not re-raised)."""
+        service = _make_service()
+        mock_exporter = MagicMock()
+        mock_exporter.submit_failure.side_effect = RuntimeError("network down")
+        service._cloud_exporter = mock_exporter
+
+        # must not raise
+        service.submit_failure_to_cloud("error", 100)
+
+    def test_default_execution_time_zero(self):
+        """Asserts execution_time_ms defaults to 0."""
+        service = _make_service()
+        mock_exporter = MagicMock()
+        service._cloud_exporter = mock_exporter
+
+        service.submit_failure_to_cloud("error")
+
+        mock_exporter.submit_failure.assert_called_once_with("error", 0)

--- a/tests/unit/github_action/test_main.py
+++ b/tests/unit/github_action/test_main.py
@@ -468,7 +468,7 @@ def _make_argv_external(
     student_name="student1",
     feedback_type="default",
     app_token="app-token",
-    grading_config_id="cfg-123",
+    grading_config_id="123",
     autograder_cloud_url="https://cloud.example.com",
     autograder_cloud_token="cloud-tok",
     include_feedback=None,
@@ -623,7 +623,7 @@ class TestSubmissionLanguageArgParsing:
         mock_service.autograder_pipeline_from_cloud.return_value = MagicMock()
         mock_service.run_autograder.return_value = execution
 
-        argv = _make_argv_external(grading_config_id="cfg-1") + ["--submission-language", "java"]
+        argv = _make_argv_external(grading_config_id="1") + ["--submission-language", "java"]
         with patch.object(sys, "argv", argv), patch(
             "github_action.main.GithubActionService", return_value=mock_service
         ):
@@ -679,7 +679,7 @@ class TestExternalModeRouting:
             sys,
             "argv",
             _make_argv_external(
-                grading_config_id="cfg-99",
+                grading_config_id="99",
                 autograder_cloud_url="https://mycloud.io",
                 autograder_cloud_token="super-secret",
                 student_name="bob",
@@ -688,7 +688,7 @@ class TestExternalModeRouting:
             run(main_module.main())
 
         mock_service.autograder_pipeline_from_cloud.assert_called_once_with(
-            "cfg-99",
+            99,
             "https://mycloud.io",
             "super-secret",
             "default",  # feedback_type

--- a/tests/unit/github_action/test_main.py
+++ b/tests/unit/github_action/test_main.py
@@ -454,3 +454,306 @@ class TestGetSubmissionFiles:
         assert ".git" not in captured_dirs[0]
         assert ".github" not in captured_dirs[0]
         assert "src" in captured_dirs[0]
+
+
+# ---------------------------------------------------------------------------
+# Helpers for external-mode tests
+# ---------------------------------------------------------------------------
+
+
+def _make_argv_external(
+    *,
+    github_token="gh-token",
+    template_preset="python",
+    student_name="student1",
+    feedback_type="default",
+    app_token="app-token",
+    grading_config_id="cfg-123",
+    autograder_cloud_url="https://cloud.example.com",
+    autograder_cloud_token="cloud-tok",
+    include_feedback=None,
+):
+    """Build a sys.argv list for external execution mode."""
+    argv = [
+        "entrypoint",
+        "--github-token", github_token,
+        "--template-preset", template_preset,
+        "--student-name", student_name,
+        "--feedback-type", feedback_type,
+        "--app-token", app_token,
+        "--execution-mode", "external",
+        "--grading-config-id", grading_config_id,
+        "--autograder-cloud-url", autograder_cloud_url,
+        "--autograder-cloud-token", autograder_cloud_token,
+    ]
+    if include_feedback is not None:
+        argv += ["--include-feedback", include_feedback]
+    return argv
+
+
+class TestExecutionModeArgParsing:
+    """
+    Argument parsing for --execution-mode and related external-mode flags.
+    """
+
+    def test_default_execution_mode_is_repo(self):
+        """Asserts --execution-mode defaults to 'repo' when not supplied."""
+        argv = _make_argv()
+        with patch.object(sys, "argv", argv):
+            parsed = main_module.parser.parse_args(argv[1:])
+        assert parsed.execution_mode == "repo"
+
+    def test_external_mode_parsed_correctly(self):
+        """Asserts --execution-mode external is accepted and stored."""
+        argv = _make_argv_external()
+        with patch.object(sys, "argv", argv):
+            parsed = main_module.parser.parse_args(argv[1:])
+        assert parsed.execution_mode == "external"
+
+    def test_invalid_mode_causes_system_exit(self):
+        """Asserts an invalid --execution-mode value causes argparse to raise SystemExit."""
+        argv = _make_argv() + ["--execution-mode", "invalid"]
+        with patch.object(sys, "argv", argv):
+            with pytest.raises(SystemExit):
+                main_module.parser.parse_args(argv[1:])
+
+    def test_external_mode_args_stored(self):
+        """Asserts grading-config-id, autograder-cloud-url and autograder-cloud-token are parsed."""
+        argv = _make_argv_external(
+            grading_config_id="cfg-42",
+            autograder_cloud_url="https://cloud.example.com",
+            autograder_cloud_token="secret",
+        )
+        with patch.object(sys, "argv", argv):
+            parsed = main_module.parser.parse_args(argv[1:])
+        assert parsed.grading_config_id == "cfg-42"
+        assert parsed.autograder_cloud_url == "https://cloud.example.com"
+        assert parsed.autograder_cloud_token == "secret"
+
+
+class TestExternalModeValidation:
+    """
+    __parser_values validation rules for external mode (fail-fast checks).
+    """
+
+    def test_missing_grading_config_id_raises_system_exit(self):
+        """Asserts SystemExit(1) is raised when external mode is used without grading-config-id."""
+        argv = _make_argv_external(grading_config_id="")
+        # Replace the empty string element pairs
+        argv = [
+            "entrypoint",
+            "--github-token", "gh-token",
+            "--template-preset", "python",
+            "--student-name", "student1",
+            "--execution-mode", "external",
+            "--autograder-cloud-url", "https://cloud.example.com",
+            "--autograder-cloud-token", "tok",
+        ]
+        mock_service = MagicMock()
+        with patch.object(sys, "argv", argv), patch(
+            "github_action.main.GithubActionService", return_value=mock_service
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                run(main_module.main())
+        assert exc_info.value.code == 1
+        mock_service.autograder_pipeline_from_cloud.assert_not_called()
+
+    def test_missing_cloud_url_raises_system_exit(self):
+        """Asserts SystemExit(1) is raised when external mode is used without autograder-cloud-url."""
+        argv = [
+            "entrypoint",
+            "--github-token", "gh-token",
+            "--template-preset", "python",
+            "--student-name", "student1",
+            "--execution-mode", "external",
+            "--grading-config-id", "cfg-123",
+            "--autograder-cloud-token", "tok",
+        ]
+        mock_service = MagicMock()
+        with patch.object(sys, "argv", argv), patch(
+            "github_action.main.GithubActionService", return_value=mock_service
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                run(main_module.main())
+        assert exc_info.value.code == 1
+        mock_service.autograder_pipeline_from_cloud.assert_not_called()
+
+    def test_missing_cloud_token_raises_system_exit(self):
+        """Asserts SystemExit(1) is raised when external mode is used without autograder-cloud-token."""
+        argv = [
+            "entrypoint",
+            "--github-token", "gh-token",
+            "--template-preset", "python",
+            "--student-name", "student1",
+            "--execution-mode", "external",
+            "--grading-config-id", "cfg-123",
+            "--autograder-cloud-url", "https://cloud.example.com",
+        ]
+        mock_service = MagicMock()
+        with patch.object(sys, "argv", argv), patch(
+            "github_action.main.GithubActionService", return_value=mock_service
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                run(main_module.main())
+        assert exc_info.value.code == 1
+        mock_service.autograder_pipeline_from_cloud.assert_not_called()
+
+
+class TestSubmissionLanguageArgParsing:
+    """Tests for --submission-language argument."""
+
+    def test_submission_language_defaults_to_none(self):
+        """Asserts --submission-language defaults to None when not supplied."""
+        argv = _make_argv_external()
+        with patch.object(sys, "argv", argv):
+            parsed = main_module.parser.parse_args(argv[1:])
+        assert parsed.submission_language is None
+
+    def test_submission_language_parsed_correctly(self):
+        """Asserts --submission-language value is stored."""
+        argv = _make_argv_external() + ["--submission-language", "python"]
+        with patch.object(sys, "argv", argv):
+            parsed = main_module.parser.parse_args(argv[1:])
+        assert parsed.submission_language == "python"
+
+    def test_submission_language_forwarded_to_service(self):
+        """Asserts --submission-language is forwarded to autograder_pipeline_from_cloud."""
+        execution = _make_pipeline_execution()
+        mock_service = MagicMock()
+        mock_service.autograder_pipeline_from_cloud.return_value = MagicMock()
+        mock_service.run_autograder.return_value = execution
+
+        argv = _make_argv_external(grading_config_id="cfg-1") + ["--submission-language", "java"]
+        with patch.object(sys, "argv", argv), patch(
+            "github_action.main.GithubActionService", return_value=mock_service
+        ):
+            run(main_module.main())
+
+        call_kwargs = mock_service.autograder_pipeline_from_cloud.call_args
+        assert call_kwargs[0][5] == "java"  # submission_language positional arg
+
+
+class TestExternalModeRouting:
+    """
+    main() routes to the correct service method based on --execution-mode.
+    """
+
+    def test_repo_mode_calls_autograder_pipeline(self):
+        """Asserts autograder_pipeline is called (not autograder_pipeline_from_cloud) in repo mode."""
+        execution = _make_pipeline_execution()
+        mock_service = MagicMock()
+        mock_service.autograder_pipeline.return_value = MagicMock()
+        mock_service.run_autograder.return_value = execution
+
+        with patch.object(sys, "argv", _make_argv()), patch(
+            "github_action.main.GithubActionService", return_value=mock_service
+        ):
+            run(main_module.main())
+
+        mock_service.autograder_pipeline.assert_called_once()
+        mock_service.autograder_pipeline_from_cloud.assert_not_called()
+
+    def test_external_mode_calls_autograder_pipeline_from_cloud(self):
+        """Asserts autograder_pipeline_from_cloud is called (not autograder_pipeline) in external mode."""
+        execution = _make_pipeline_execution()
+        mock_service = MagicMock()
+        mock_service.autograder_pipeline_from_cloud.return_value = MagicMock()
+        mock_service.run_autograder.return_value = execution
+
+        with patch.object(sys, "argv", _make_argv_external()), patch(
+            "github_action.main.GithubActionService", return_value=mock_service
+        ):
+            run(main_module.main())
+
+        mock_service.autograder_pipeline_from_cloud.assert_called_once()
+        mock_service.autograder_pipeline.assert_not_called()
+
+    def test_external_mode_passes_cloud_params_to_service(self):
+        """Asserts cloud URL, token, config ID, feedback mode, and student name are forwarded."""
+        execution = _make_pipeline_execution()
+        mock_service = MagicMock()
+        mock_service.autograder_pipeline_from_cloud.return_value = MagicMock()
+        mock_service.run_autograder.return_value = execution
+
+        with patch.object(
+            sys,
+            "argv",
+            _make_argv_external(
+                grading_config_id="cfg-99",
+                autograder_cloud_url="https://mycloud.io",
+                autograder_cloud_token="super-secret",
+                student_name="bob",
+            ),
+        ), patch("github_action.main.GithubActionService", return_value=mock_service):
+            run(main_module.main())
+
+        mock_service.autograder_pipeline_from_cloud.assert_called_once_with(
+            "cfg-99",
+            "https://mycloud.io",
+            "super-secret",
+            "default",  # feedback_type
+            "bob",      # student_name
+            None,       # submission_language (not provided)
+        )
+
+    def test_external_mode_runs_autograder_after_cloud_pipeline(self):
+        """Asserts run_autograder is still called after building the pipeline from cloud config."""
+        execution = _make_pipeline_execution(final_score=72.0)
+        mock_pipeline = MagicMock()
+        mock_service = MagicMock()
+        mock_service.autograder_pipeline_from_cloud.return_value = mock_pipeline
+        mock_service.run_autograder.return_value = execution
+
+        with patch.object(sys, "argv", _make_argv_external()), patch(
+            "github_action.main.GithubActionService", return_value=mock_service
+        ):
+            run(main_module.main())
+
+        mock_service.run_autograder.assert_called_once()
+
+    def test_external_mode_none_grading_result_raises_system_exit(self):
+        """Asserts SystemExit(1) is raised when external mode pipeline returns None result."""
+        execution = MagicMock()
+        execution.result = None
+        mock_service = MagicMock()
+        mock_service.autograder_pipeline_from_cloud.return_value = MagicMock()
+        mock_service.run_autograder.return_value = execution
+
+        with patch.object(sys, "argv", _make_argv_external()), patch(
+            "github_action.main.GithubActionService", return_value=mock_service
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                run(main_module.main())
+
+        assert exc_info.value.code == 1
+
+    def test_external_mode_failure_calls_submit_failure_to_cloud(self):
+        """Asserts submit_failure_to_cloud is called when grading raises an exception."""
+        mock_service = MagicMock()
+        mock_service.autograder_pipeline_from_cloud.return_value = MagicMock()
+        mock_service.run_autograder.side_effect = RuntimeError("sandbox crash")
+
+        with patch.object(sys, "argv", _make_argv_external()), patch(
+            "github_action.main.GithubActionService", return_value=mock_service
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                run(main_module.main())
+
+        assert exc_info.value.code == 1
+        mock_service.submit_failure_to_cloud.assert_called_once()
+        call_args = mock_service.submit_failure_to_cloud.call_args
+        assert "sandbox crash" in call_args[0][0]
+
+    def test_external_mode_failure_not_called_when_config_fetch_fails(self):
+        """Asserts submit_failure_to_cloud is NOT called when pipeline build itself raises."""
+        mock_service = MagicMock()
+        mock_service.autograder_pipeline_from_cloud.side_effect = RuntimeError("cloud unreachable")
+
+        with patch.object(sys, "argv", _make_argv_external()), patch(
+            "github_action.main.GithubActionService", return_value=mock_service
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                run(main_module.main())
+
+        assert exc_info.value.code == 1
+        mock_service.submit_failure_to_cloud.assert_not_called()

--- a/tests/unit/github_action/test_main.py
+++ b/tests/unit/github_action/test_main.py
@@ -694,6 +694,7 @@ class TestExternalModeRouting:
             "default",  # feedback_type
             "bob",      # student_name
             None,       # submission_language (not provided)
+            "en",       # locale (default)
         )
 
     def test_external_mode_runs_autograder_after_cloud_pipeline(self):

--- a/tests/unit/test_extract_file.py
+++ b/tests/unit/test_extract_file.py
@@ -3,39 +3,28 @@ Unit tests for SandboxContainer.extract_file.
 
 Tests cover:
 - Successful file extraction with UTF-8 content
+- Successful extraction with latin-1 fallback
 - Missing file (FileNotFoundError)
 - Oversized file (ValueError)
-- Invalid tar stream (RuntimeError)
-- Archive with no regular file (ValueError)
+- base64 command failure (RuntimeError)
+- Non-regular path / exec_run failure (FileNotFoundError)
+- exec_run raises exception (RuntimeError)
 """
 
-import io
-import tarfile
+import base64
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 from sandbox_manager.sandbox_container import SandboxContainer
 from sandbox_manager.models.sandbox_models import Language, ExtractedFile
 
 
-def _make_tar_bytes(filename: str, content: bytes) -> bytes:
-    """Build an in-memory tar archive containing a single file."""
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w") as tar:
-        info = tarfile.TarInfo(name=filename)
-        info.size = len(content)
-        tar.addfile(info, io.BytesIO(content))
-    return buf.getvalue()
-
-
-def _make_tar_directory_only(dirname: str) -> bytes:
-    """Build a tar archive containing only a directory entry (no regular file)."""
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w") as tar:
-        info = tarfile.TarInfo(name=dirname)
-        info.type = tarfile.DIRTYPE
-        tar.addfile(info)
-    return buf.getvalue()
+def _exec_run_result(exit_code: int, output: bytes) -> MagicMock:
+    """Build a mock exec_run return value."""
+    r = MagicMock()
+    r.exit_code = exit_code
+    r.output = output
+    return r
 
 
 class TestExtractFile(unittest.TestCase):
@@ -53,26 +42,31 @@ class TestExtractFile(unittest.TestCase):
     def test_success_utf8(self):
         """Successful extraction of a UTF-8 text file."""
         content = "comparacoes: 10\nmovimentacoes: 4\n"
-        tar_bytes = _make_tar_bytes("output.txt", content.encode("utf-8"))
-        stat = {"name": "output.txt", "size": len(content)}
+        content_bytes = content.encode("utf-8")
+        encoded = base64.b64encode(content_bytes)
 
-        self.mock_container.get_archive.return_value = (iter([tar_bytes]), stat)
+        self.mock_container.exec_run.side_effect = [
+            _exec_run_result(0, str(len(content_bytes)).encode()),
+            _exec_run_result(0, encoded),
+        ]
 
         result = self.sandbox.extract_file("/app/output.txt")
 
         self.assertIsInstance(result, ExtractedFile)
         self.assertEqual(result.path, "/app/output.txt")
         self.assertEqual(result.content_text, content)
-        self.assertEqual(result.size, len(content.encode("utf-8")))
+        self.assertEqual(result.size, len(content_bytes))
         self.assertEqual(result.encoding, "utf-8")
 
     def test_success_latin1_fallback(self):
         """Falls back to latin-1 when content is not valid UTF-8."""
         content_bytes = b"\xe9\xe8\xea"  # latin-1 chars, invalid UTF-8
-        tar_bytes = _make_tar_bytes("data.bin", content_bytes)
-        stat = {"name": "data.bin", "size": len(content_bytes)}
+        encoded = base64.b64encode(content_bytes)
 
-        self.mock_container.get_archive.return_value = (iter([tar_bytes]), stat)
+        self.mock_container.exec_run.side_effect = [
+            _exec_run_result(0, str(len(content_bytes)).encode()),
+            _exec_run_result(0, encoded),
+        ]
 
         result = self.sandbox.extract_file("/app/data.bin")
 
@@ -80,8 +74,8 @@ class TestExtractFile(unittest.TestCase):
         self.assertEqual(result.content_bytes, content_bytes)
 
     def test_file_not_found(self):
-        """Raises FileNotFoundError when Docker returns 404."""
-        self.mock_container.get_archive.side_effect = Exception("404 Client Error: Not Found")
+        """Raises FileNotFoundError when the stat check fails."""
+        self.mock_container.exec_run.return_value = _exec_run_result(1, b"")
 
         with self.assertRaises(FileNotFoundError) as ctx:
             self.sandbox.extract_file("/app/missing.txt")
@@ -89,54 +83,40 @@ class TestExtractFile(unittest.TestCase):
         self.assertIn("missing.txt", str(ctx.exception))
 
     def test_file_not_found_no_such(self):
-        """Raises FileNotFoundError when Docker says 'No such file'."""
-        self.mock_container.get_archive.side_effect = Exception("No such file or directory")
+        """Raises FileNotFoundError when stat returns non-zero exit code."""
+        self.mock_container.exec_run.return_value = _exec_run_result(1, b"No such file or directory")
 
         with self.assertRaises(FileNotFoundError):
             self.sandbox.extract_file("/app/gone.txt")
 
     def test_oversized_file(self):
         """Raises ValueError when file exceeds max_bytes."""
-        big_content = b"x" * 200
-        tar_bytes = _make_tar_bytes("big.txt", big_content)
-        stat = {"name": "big.txt", "size": 200}
-
-        self.mock_container.get_archive.return_value = (iter([tar_bytes]), stat)
+        self.mock_container.exec_run.return_value = _exec_run_result(0, b"200")
 
         with self.assertRaises(ValueError) as ctx:
             self.sandbox.extract_file("/app/big.txt", max_bytes=100)
 
         self.assertIn("exceeds maximum size", str(ctx.exception))
 
-    def test_invalid_tar_stream(self):
-        """Raises RuntimeError when tar stream is corrupted."""
-        self.mock_container.get_archive.return_value = (iter([b"not-a-tar"]), {})
+    def test_base64_command_failure(self):
+        """Raises RuntimeError when base64 read command fails."""
+        content_bytes = b"hello"
+        self.mock_container.exec_run.side_effect = [
+            _exec_run_result(0, str(len(content_bytes)).encode()),
+            _exec_run_result(1, b"permission denied"),
+        ]
 
         with self.assertRaises(RuntimeError) as ctx:
             self.sandbox.extract_file("/app/file.txt")
 
-        self.assertIn("Failed to read tar stream", str(ctx.exception))
-
-    def test_no_regular_file_in_archive(self):
-        """Raises ValueError when archive contains only a directory."""
-        tar_bytes = _make_tar_directory_only("somedir")
-        stat = {"name": "somedir", "size": 0}
-
-        self.mock_container.get_archive.return_value = (iter([tar_bytes]), stat)
-
-        with self.assertRaises(ValueError) as ctx:
-            self.sandbox.extract_file("/app/somedir")
-
-        self.assertIn("No regular file", str(ctx.exception))
+        self.assertIn("Failed to read file", str(ctx.exception))
 
     def test_docker_api_generic_error(self):
-        """Raises RuntimeError for non-404 Docker errors."""
-        self.mock_container.get_archive.side_effect = Exception("Connection refused")
+        """Raises RuntimeError when exec_run raises an unexpected exception."""
+        self.mock_container.exec_run.side_effect = Exception("Connection refused")
 
-        with self.assertRaises(RuntimeError) as ctx:
+        with self.assertRaises(Exception):
             self.sandbox.extract_file("/app/file.txt")
-
-        self.assertIn("Failed to retrieve archive", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/tests/web/test_external_results.py
+++ b/tests/web/test_external_results.py
@@ -13,7 +13,6 @@ from web.database import session
 
 TEST_TOKEN = "test-external-results-token"
 
-
 @pytest.fixture(scope="module", autouse=True)
 def mock_external_services():
     """Mock external services for all tests."""
@@ -33,9 +32,7 @@ def mock_external_services():
         mock_template.get_instance.return_value = mock_service
         yield
 
-
 from web.main import app
-
 
 @pytest.fixture(autouse=True)
 def _set_integration_token():
@@ -46,10 +43,8 @@ def _set_integration_token():
     yield
     auth_module.integration_auth_config = cfg
 
-
 def _auth_header() -> dict:
     return {"Authorization": f"Bearer {TEST_TOKEN}"}
-
 
 @pytest.fixture
 async def test_db():
@@ -76,7 +71,6 @@ async def test_db():
         session.engine = old_engine
     await engine.dispose()
 
-
 @pytest.fixture
 async def client(test_db):
     """Create test client."""
@@ -85,7 +79,6 @@ async def client(test_db):
         base_url="http://test"
     ) as ac:
         yield ac
-
 
 async def _create_config(client, external_id="ext-assign-1"):
     """Helper to create a grading config and return its internal ID."""
@@ -102,9 +95,9 @@ async def _create_config(client, external_id="ext-assign-1"):
     assert resp.status_code == 200
     return resp.json()
 
-
-# ── GET /api/v1/configs/id/{config_id} ─────────────────────────
-
+# ---------------------------------------------------------------------------
+# GET /api/v1/configs/id/{config_id}
+# ---------------------------------------------------------------------------
 
 class TestGetConfigById:
     """Tests for fetching grading config by internal ID."""
@@ -153,9 +146,9 @@ class TestGetConfigById:
         for key in required_keys:
             assert key in data, f"Missing key: {key}"
 
-
-# ── POST /api/v1/submissions/external-results ──────────────────
-
+# ---------------------------------------------------------------------------
+# POST /api/v1/submissions/external-results
+# ---------------------------------------------------------------------------
 
 class TestExternalResultIngestion:
     """Tests for external grading result ingestion."""

--- a/tests/web/test_integration_auth.py
+++ b/tests/web/test_integration_auth.py
@@ -11,9 +11,7 @@ from web.config.auth import IntegrationAuthConfig
 from web.database.base import Base
 from web.database import session
 
-
 TEST_TOKEN = "test-integration-secret-token-abc123"
-
 
 @pytest.fixture(scope="module", autouse=True)
 def mock_external_services():
@@ -34,9 +32,7 @@ def mock_external_services():
         mock_template.get_instance.return_value = mock_service
         yield
 
-
 from web.main import app
-
 
 @pytest.fixture(autouse=True)
 def _set_integration_token():
@@ -47,7 +43,6 @@ def _set_integration_token():
     auth_module.integration_auth_config = cfg
     yield
     auth_module.integration_auth_config = old_integration_auth_config
-
 
 @pytest.fixture
 async def test_db():
@@ -74,7 +69,6 @@ async def test_db():
         session.engine = old_engine
     await engine.dispose()
 
-
 @pytest.fixture
 async def client(test_db):
     """Create test client."""
@@ -84,10 +78,8 @@ async def client(test_db):
     ) as ac:
         yield ac
 
-
 def _auth_header(token: str = TEST_TOKEN) -> dict:
     return {"Authorization": f"Bearer {token}"}
-
 
 async def _create_config(client):
     """Helper — config creation is public, no auth needed."""
@@ -102,9 +94,9 @@ async def _create_config(client):
     assert resp.status_code == 200
     return resp.json()
 
-
-# ── Missing token → 401 ────────────────────────────────────────
-
+# ---------------------------------------------------------------------------
+# Missing token → 401
+# ---------------------------------------------------------------------------
 
 class TestAuthMissingToken:
     """Requests without a token get 401."""
@@ -129,9 +121,9 @@ class TestAuthMissingToken:
         resp = await client.post("/api/v1/submissions/external-results", json=payload)
         assert resp.status_code == 401
 
-
-# ── Wrong token → 401 ──────────────────────────────────────────
-
+# ---------------------------------------------------------------------------
+# Wrong token → 401
+# ---------------------------------------------------------------------------
 
 class TestAuthInvalidToken:
     """Requests with a wrong token get 401."""
@@ -163,9 +155,9 @@ class TestAuthInvalidToken:
         )
         assert resp.status_code == 401
 
-
-# ── Valid token → success ───────────────────────────────────────
-
+# ---------------------------------------------------------------------------
+# Valid token → success
+# ---------------------------------------------------------------------------
 
 class TestAuthValidToken:
     """Valid token grants access to protected endpoints."""
@@ -209,9 +201,9 @@ class TestAuthValidToken:
         )
         assert resp.status_code == 404
 
-
-# ── Public endpoints stay public ────────────────────────────────
-
+# ---------------------------------------------------------------------------
+# Public endpoints stay public
+# ---------------------------------------------------------------------------
 
 class TestPublicEndpointsUnaffected:
     """Token auth must not affect public endpoints."""


### PR DESCRIPTION
This pull request introduces support for an "external mode" in the Autograder GitHub Action, allowing grading configuration and result submission to be handled via the Autograder Cloud API instead of repository-local files. The changes add new action inputs and environment variables, document the external mode workflow, and update both the abstract exporter interface and the export step to support richer context. Documentation is significantly expanded to cover usage, configuration, and error handling for external mode.

**External Mode Integration**

* Added new inputs to `action.yml` for external mode: `execution-mode`, `grading-config-id`, `autograder-cloud-url`, `autograder-cloud-token`, and `submission-language`, with corresponding environment variable exports. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R31-R46) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R66-R70)
* Comprehensive documentation for external mode added to `docs/github_action/README.md`, `docs/github_action/configuration.md`, and `docs/API.md`, including usage instructions, workflow examples, and error handling. [[1]](diffhunk://#diff-381f8ef20846e405d8e58448305da6c0ab290113ab23d1d4142823096d7b780eL7-R33) [[2]](diffhunk://#diff-381f8ef20846e405d8e58448305da6c0ab290113ab23d1d4142823096d7b780eR44-R45) [[3]](diffhunk://#diff-381f8ef20846e405d8e58448305da6c0ab290113ab23d1d4142823096d7b780eR69-R70) [[4]](diffhunk://#diff-381f8ef20846e405d8e58448305da6c0ab290113ab23d1d4142823096d7b780eR79) [[5]](diffhunk://#diff-f319aeec7a86c6735082987a0e1e58b4952b19c5a34f2edbe585713eb24486a2R7-R8) [[6]](diffhunk://#diff-f319aeec7a86c6735082987a0e1e58b4952b19c5a34f2edbe585713eb24486a2R38-R86) [[7]](diffhunk://#diff-f319aeec7a86c6735082987a0e1e58b4952b19c5a34f2edbe585713eb24486a2L75-R147) [[8]](diffhunk://#diff-f319aeec7a86c6735082987a0e1e58b4952b19c5a34f2edbe585713eb24486a2R165) [[9]](diffhunk://#diff-b57590968a12cee85a37c1b91d8cc7092cd8b68e50b242c39a178121db82a797R856-R951)

**Exporter Interface and Pipeline Updates**

* Enhanced the `Exporter` abstract class with a new `export_with_context` method, allowing exporters to access the full `PipelineExecution` for richer exports; default implementation maintains backward compatibility. [[1]](diffhunk://#diff-71a7b35b2290ad38399574373e9a0a6628ae339325b2e1073a48dc23e63ad20eR3-R9) [[2]](diffhunk://#diff-71a7b35b2290ad38399574373e9a0a6628ae339325b2e1073a48dc23e63ad20eR18-R24) [[3]](diffhunk://#diff-71a7b35b2290ad38399574373e9a0a6628ae339325b2e1073a48dc23e63ad20eL26-R55)
* Updated `ExportStep` to call `export_with_context` instead of the legacy `export` method, enabling external mode exporters to access all grading context. [[1]](diffhunk://#diff-a71cbc7918ce73467b4cd6d1a878d71301385e4dda0995ed6dd31b0fb63e21c3L2) [[2]](diffhunk://#diff-a71cbc7918ce73467b4cd6d1a878d71301385e4dda0995ed6dd31b0fb63e21c3L33-R36)

**Behavioral Notes and Validation**

* In external mode, `include-feedback` is taken from the cloud config, not the action input; `submission-language` is validated against the config's supported languages. All required secrets and inputs for external mode are documented, with validation and error handling described. [[1]](diffhunk://#diff-381f8ef20846e405d8e58448305da6c0ab290113ab23d1d4142823096d7b780eR69-R70) [[2]](diffhunk://#diff-f319aeec7a86c6735082987a0e1e58b4952b19c5a34f2edbe585713eb24486a2R38-R86) [[3]](diffhunk://#diff-f319aeec7a86c6735082987a0e1e58b4952b19c5a34f2edbe585713eb24486a2L75-R147)

These changes make it possible to centrally manage grading configurations and results using Autograder Cloud, improving scalability for organizations with many assignments or courses.