### PR TITLE
fix: restore error handling in deliberate execution service

### DIFF
--- a/tests/web/test_deliberate_execution_service.py
+++ b/tests/web/test_deliberate_execution_service.py
@@ -191,9 +191,39 @@ async def test_execute_code_execution_error():
 
     assert len(response.results) == 1
     assert response.results[0].category == ResponseCategory.SYSTEM_ERROR
-    assert "container crashed" in response.results[0].error_message
+    assert response.results[0].error_message == "An unexpected error occurred. Please try again later."
+    assert "container crashed" not in response.results[0].error_message
     assert response.results[0].output == ""
     # Sandbox must still be released in the finally block
+    mock_manager.release_sandbox.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# execute_code – execution error with multiple test cases
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_execute_code_execution_error_multiple_test_cases():
+    """On exception, SYSTEM_ERROR count matches the number of requested test cases."""
+    mock_sandbox = Mock()
+    mock_sandbox.prepare_workdir = Mock()
+
+    mock_manager = Mock()
+    mock_manager.get_sandbox = Mock(return_value=mock_sandbox)
+    mock_manager.release_sandbox = Mock()
+
+    request = _make_request(test_cases=[["1"], ["2"], ["3"]])
+
+    with patch("web.service.deliberate_execution_service.get_sandbox_manager", return_value=mock_manager), \
+         patch("asyncio.to_thread", new=AsyncMock(side_effect=RuntimeError("container crashed"))):
+
+        response = await execute_code(request)
+
+    assert len(response.results) == 3
+    for result in response.results:
+        assert result.category == ResponseCategory.SYSTEM_ERROR
+        assert result.error_message == "An unexpected error occurred. Please try again later."
+        assert result.output == ""
     mock_manager.release_sandbox.assert_called_once()
 
 

--- a/web/service/deliberate_execution_service.py
+++ b/web/service/deliberate_execution_service.py
@@ -187,14 +187,16 @@ async def execute_code(request: DeliberateCodeExecutionRequest) -> DeliberateCod
 
     except Exception as e:  # pylint: disable=broad-exception-caught
         logger.error("Execution failed: %s", e, exc_info=True)
+        num_results = len(request.test_cases) if request.test_cases else 1
         return DeliberateCodeExecutionResponse(
             results=[
                 DeliberateCodeExecutionResult(
                     output="",
                     category=ResponseCategory.SYSTEM_ERROR,
-                    error_message=f"Execution failed: {str(e)}",
+                    error_message="An unexpected error occurred. Please try again later.",
                     execution_time=0.0
                 )
+                for _ in range(num_results)
             ]
         )
 

--- a/web/service/deliberate_execution_service.py
+++ b/web/service/deliberate_execution_service.py
@@ -185,6 +185,19 @@ async def execute_code(request: DeliberateCodeExecutionRequest) -> DeliberateCod
 
         return DeliberateCodeExecutionResponse(results=execution_results)
 
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logger.error("Execution failed: %s", e, exc_info=True)
+        return DeliberateCodeExecutionResponse(
+            results=[
+                DeliberateCodeExecutionResult(
+                    output="",
+                    category=ResponseCategory.SYSTEM_ERROR,
+                    error_message=f"Execution failed: {str(e)}",
+                    execution_time=0.0
+                )
+            ]
+        )
+
     finally:
         # Always release sandbox back to pool
         if sandbox and sandbox_manager:


### PR DESCRIPTION
The except block was accidentally removed during the asset injection refactor, causing unhandled exceptions (e.g. S3 asset not found) to propagate as raw 500 errors instead of structured SYSTEM_ERROR responses.