### PR TITLE
fix: prevent event-loop blocking in deliberate execution sandbox lifecycle

### DIFF
--- a/tests/web/test_api_endpoints.py
+++ b/tests/web/test_api_endpoints.py
@@ -14,6 +14,8 @@ from sqlalchemy.pool import StaticPool
 
 from web.database.base import Base
 from web.database import session
+from web.schemas.execution import DeliberateCodeExecutionResponse, DeliberateCodeExecutionResult
+from sandbox_manager.models.sandbox_models import ResponseCategory
 
 
 # Mock external dependencies before importing app
@@ -103,6 +105,47 @@ async def test_readiness_check(client):
     data = response.json()
     assert "ready" in data
     assert "timestamp" in data
+
+
+@pytest.mark.asyncio
+async def test_execute_endpoint_contract_and_value_error_mapping(client):
+    """Test /api/v1/execute response contract and ValueError mapping."""
+    execute_request = {
+        "language": "python",
+        "submission_files": [{"filename": "main.py", "content": "print('ok')"}],
+        "program_command": "python main.py",
+    }
+
+    service_response = DeliberateCodeExecutionResponse(
+        results=[
+            DeliberateCodeExecutionResult(
+                output="ok\n",
+                category=ResponseCategory.SUCCESS,
+                error_message=None,
+                execution_time=0.12,
+            )
+        ]
+    )
+
+    with patch("web.api.v1.execution.execute_code", new=AsyncMock(return_value=service_response)):
+        response = await client.post("/api/v1/execute", json=execute_request)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "results" in body
+    assert len(body["results"]) == 1
+    result = body["results"][0]
+    assert set(result.keys()) == {"output", "category", "error_message", "execution_time"}
+    assert result["output"] == "ok\n"
+    assert result["category"] == "success"
+    assert result["error_message"] is None
+    assert isinstance(result["execution_time"], float)
+
+    with patch("web.api.v1.execution.execute_code", new=AsyncMock(side_effect=ValueError("invalid request"))):
+        error_response = await client.post("/api/v1/execute", json=execute_request)
+
+    assert error_response.status_code == 400
+    assert error_response.json()["detail"] == "invalid request"
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_deliberate_execution_service.py
+++ b/tests/web/test_deliberate_execution_service.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, AsyncMock, patch
 
 from web.service.deliberate_execution_service import execute_code, _get_error_message
 from web.schemas.execution import DeliberateCodeExecutionRequest, DeliberateCodeExecutionResponse
-from sandbox_manager.models.sandbox_models import ResponseCategory, CommandResponse
+from sandbox_manager.models.sandbox_models import ResponseCategory, CommandResponse, Language
 
 
 def _make_request(language="python", files=None, command="python main.py", test_cases=None):
@@ -29,6 +29,11 @@ def _make_command_response(stdout="hello\n", stderr="", exit_code=0,
         execution_time=execution_time,
         category=category,
     )
+
+
+async def _execute_in_thread(fn, *args, **kwargs):
+    """Run a mocked asyncio.to_thread call by invoking the function directly."""
+    return fn(*args, **kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -126,7 +131,8 @@ async def test_execute_code_success_no_inputs():
     request = _make_request(test_cases=None)
 
     with patch("web.service.deliberate_execution_service.get_sandbox_manager", return_value=mock_manager), \
-         patch("asyncio.to_thread", new=AsyncMock(return_value=cmd_response)):
+         patch("asyncio.to_thread", new_callable=AsyncMock) as mock_to_thread:
+        mock_to_thread.side_effect = _execute_in_thread
 
         response = await execute_code(request)
 
@@ -136,6 +142,10 @@ async def test_execute_code_success_no_inputs():
     assert response.results[0].output == "hello\n"
     assert response.results[0].error_message is None
     mock_manager.release_sandbox.assert_called_once()
+    mock_to_thread.assert_any_await(mock_manager.get_sandbox, Language.PYTHON)
+    mock_to_thread.assert_any_await(mock_sandbox.prepare_workdir, mock_sandbox.prepare_workdir.call_args[0][0])
+    mock_to_thread.assert_any_await(mock_sandbox.run_command, request.program_command, timeout=30, workdir="/app")
+    mock_to_thread.assert_any_await(mock_manager.release_sandbox, Language.PYTHON, mock_sandbox)
 
 
 # ---------------------------------------------------------------------------
@@ -158,7 +168,8 @@ async def test_execute_code_success_with_inputs():
     request = _make_request(test_cases=[["5", "7"]])
 
     with patch("web.service.deliberate_execution_service.get_sandbox_manager", return_value=mock_manager), \
-         patch("asyncio.to_thread", new=AsyncMock(return_value=cmd_response)):
+         patch("asyncio.to_thread", new_callable=AsyncMock) as mock_to_thread:
+        mock_to_thread.side_effect = _execute_in_thread
 
         response = await execute_code(request)
 
@@ -166,6 +177,16 @@ async def test_execute_code_success_with_inputs():
     assert response.results[0].category == ResponseCategory.SUCCESS
     assert response.results[0].output == "42\n"
     mock_manager.release_sandbox.assert_called_once()
+    mock_to_thread.assert_any_await(mock_manager.get_sandbox, Language.PYTHON)
+    mock_to_thread.assert_any_await(mock_sandbox.prepare_workdir, mock_sandbox.prepare_workdir.call_args[0][0])
+    mock_to_thread.assert_any_await(
+        mock_sandbox.run_commands,
+        ["5", "7"],
+        request.program_command,
+        timeout=30,
+        workdir="/app"
+    )
+    mock_to_thread.assert_any_await(mock_manager.release_sandbox, Language.PYTHON, mock_sandbox)
 
 
 # ---------------------------------------------------------------------------
@@ -177,6 +198,7 @@ async def test_execute_code_execution_error():
     """execute_code returns a SYSTEM_ERROR response when an exception is raised."""
     mock_sandbox = Mock()
     mock_sandbox.prepare_workdir = Mock()
+    mock_sandbox.run_command = Mock(side_effect=RuntimeError("container crashed"))
 
     mock_manager = Mock()
     mock_manager.get_sandbox = Mock(return_value=mock_sandbox)
@@ -185,7 +207,8 @@ async def test_execute_code_execution_error():
     request = _make_request()
 
     with patch("web.service.deliberate_execution_service.get_sandbox_manager", return_value=mock_manager), \
-         patch("asyncio.to_thread", new=AsyncMock(side_effect=RuntimeError("container crashed"))):
+         patch("asyncio.to_thread", new_callable=AsyncMock) as mock_to_thread:
+        mock_to_thread.side_effect = _execute_in_thread
 
         response = await execute_code(request)
 
@@ -196,6 +219,9 @@ async def test_execute_code_execution_error():
     assert response.results[0].output == ""
     # Sandbox must still be released in the finally block
     mock_manager.release_sandbox.assert_called_once()
+    mock_to_thread.assert_any_await(mock_manager.get_sandbox, Language.PYTHON)
+    mock_to_thread.assert_any_await(mock_sandbox.prepare_workdir, mock_sandbox.prepare_workdir.call_args[0][0])
+    mock_to_thread.assert_any_await(mock_manager.release_sandbox, Language.PYTHON, mock_sandbox)
 
 
 # ---------------------------------------------------------------------------
@@ -207,6 +233,7 @@ async def test_execute_code_execution_error_multiple_test_cases():
     """On exception, SYSTEM_ERROR count matches the number of requested test cases."""
     mock_sandbox = Mock()
     mock_sandbox.prepare_workdir = Mock()
+    mock_sandbox.run_commands = Mock(side_effect=RuntimeError("container crashed"))
 
     mock_manager = Mock()
     mock_manager.get_sandbox = Mock(return_value=mock_sandbox)
@@ -215,7 +242,8 @@ async def test_execute_code_execution_error_multiple_test_cases():
     request = _make_request(test_cases=[["1"], ["2"], ["3"]])
 
     with patch("web.service.deliberate_execution_service.get_sandbox_manager", return_value=mock_manager), \
-         patch("asyncio.to_thread", new=AsyncMock(side_effect=RuntimeError("container crashed"))):
+         patch("asyncio.to_thread", new_callable=AsyncMock) as mock_to_thread:
+        mock_to_thread.side_effect = _execute_in_thread
 
         response = await execute_code(request)
 
@@ -225,6 +253,9 @@ async def test_execute_code_execution_error_multiple_test_cases():
         assert result.error_message == "An unexpected error occurred. Please try again later."
         assert result.output == ""
     mock_manager.release_sandbox.assert_called_once()
+    mock_to_thread.assert_any_await(mock_manager.get_sandbox, Language.PYTHON)
+    mock_to_thread.assert_any_await(mock_sandbox.prepare_workdir, mock_sandbox.prepare_workdir.call_args[0][0])
+    mock_to_thread.assert_any_await(mock_manager.release_sandbox, Language.PYTHON, mock_sandbox)
 
 
 # ---------------------------------------------------------------------------
@@ -243,6 +274,7 @@ async def test_execute_code_runtime_error_response():
 
     mock_sandbox = Mock()
     mock_sandbox.prepare_workdir = Mock()
+    mock_sandbox.run_command = Mock(return_value=cmd_response)
 
     mock_manager = Mock()
     mock_manager.get_sandbox = Mock(return_value=mock_sandbox)
@@ -251,7 +283,8 @@ async def test_execute_code_runtime_error_response():
     request = _make_request()
 
     with patch("web.service.deliberate_execution_service.get_sandbox_manager", return_value=mock_manager), \
-         patch("asyncio.to_thread", new=AsyncMock(return_value=cmd_response)):
+         patch("asyncio.to_thread", new_callable=AsyncMock) as mock_to_thread:
+        mock_to_thread.side_effect = _execute_in_thread
 
         response = await execute_code(request)
 
@@ -259,3 +292,6 @@ async def test_execute_code_runtime_error_response():
     assert response.results[0].category == ResponseCategory.RUNTIME_ERROR
     assert "Runtime error occurred" in response.results[0].error_message
     assert "ZeroDivisionError" in response.results[0].error_message
+    mock_to_thread.assert_any_await(mock_manager.get_sandbox, Language.PYTHON)
+    mock_to_thread.assert_any_await(mock_sandbox.prepare_workdir, mock_sandbox.prepare_workdir.call_args[0][0])
+    mock_to_thread.assert_any_await(mock_manager.release_sandbox, Language.PYTHON, mock_sandbox)

--- a/web/service/deliberate_execution_service.py
+++ b/web/service/deliberate_execution_service.py
@@ -143,7 +143,7 @@ async def execute_code(request: DeliberateCodeExecutionRequest) -> DeliberateCod
     # Acquire sandbox
     sandbox = None
     try:
-        sandbox = sandbox_manager.get_sandbox(language)
+        sandbox = await asyncio.to_thread(sandbox_manager.get_sandbox, language)
         logger.info("Acquired sandbox for %s", language.value)
 
         # Convert submission files to the format expected by sandbox
@@ -156,7 +156,7 @@ async def execute_code(request: DeliberateCodeExecutionRequest) -> DeliberateCod
         }
 
         # Prepare workdir with submission files
-        sandbox.prepare_workdir(files_dict)
+        await asyncio.to_thread(sandbox.prepare_workdir, files_dict)
         logger.info("Prepared workdir with %d file(s)", len(files_dict))
 
         # Resolve and inject assets if provided
@@ -203,5 +203,5 @@ async def execute_code(request: DeliberateCodeExecutionRequest) -> DeliberateCod
     finally:
         # Always release sandbox back to pool
         if sandbox and sandbox_manager:
-            sandbox_manager.release_sandbox(language, sandbox)
+            await asyncio.to_thread(sandbox_manager.release_sandbox, language, sandbox)
             logger.info("Released sandbox for %s", language.value)


### PR DESCRIPTION
## Context

Issue #314 identified event-loop blocking in deliberate execution because synchronous sandbox lifecycle calls were executed directly in async request flow (get_sandbox, prepare_workdir, release_sandbox).

## Solution

- Offloaded sandbox lifecycle calls in web/service/deliberate_execution_service.py using asyncio.to_thread:
  - sandbox acquisition
  - workdir preparation
  - sandbox release in finally
- Kept existing response schema and error behavior unchanged.
- Updated tests/web/test_deliberate_execution_service.py to mock asyncio.to_thread for multiple call types and assert offloading for acquire/prepare/release.
- Added API regression test in tests/web/test_api_endpoints.py for /api/v1/execute contract and ValueError to HTTP 400 mapping.

## Further clarifications

- Full pytest -q currently hits a pre-existing collection error in tests/performance/run_fresh_test.py unrelated to this change.
- Relevant targeted suites pass:
  - pytest tests/web/test_deliberate_execution_service.py -q
  - pytest tests/web/test_api_endpoints.py -q

## Related issues

Closes #314

## Checklist

- [x] I linked the related issue(s) and explained the motivation.
- [x] I kept this PR focused and scoped to a single concern.
- [x] I added or updated tests for changed behavior (or explained why not needed).
- [x] I ran the relevant tests locally.
- [ ] I updated documentation when needed (README/docs/API examples).
- [ ] This PR introduces API contract changes (request/response/endpoint/DTO).
- [ ] If API changed, I documented compatibility or migration notes.
- [ ] This PR includes breaking changes.
- [ ] If breaking, I clearly described impact and migration steps.
