### PR TITLE
Rename CRITERIA_ASSETS_* to EXTERNAL_ASSETS_*

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,8 +29,8 @@ JSON_LOGS=false  # Set to 'true' for JSON-formatted logs (recommended for produc
 # UPSTASH_REDIS_TOKEN=your-redis-token
 
 # S3 Assets Configuration
-CRITERIA_ASSETS_BUCKET_NAME=autograder-assets
-CRITERIA_ASSETS_IN_MEMORY_CACHE_LIMIT=100
+EXTERNAL_ASSETS_BUCKET_NAME=autograder-assets
+EXTERNAL_ASSETS_IN_MEMORY_CACHE_LIMIT=100
 AWS_ACCESS_KEY_ID=test
 AWS_SECRET_ACCESS_KEY=test
 AWS_REGION=us-east-1

--- a/autograder/services/assets/resolver.py
+++ b/autograder/services/assets/resolver.py
@@ -10,7 +10,7 @@ logger = logging.getLogger("AssetSourceResolver")
 
 class AssetSourceResolver:
     def __init__(self):
-        in_memory_limit = int(os.getenv("CRITERIA_ASSETS_IN_MEMORY_CACHE_LIMIT", "100"))
+        in_memory_limit = int(os.getenv("EXTERNAL_ASSETS_IN_MEMORY_CACHE_LIMIT", "100"))
         self.cache_manager = AssetCacheManager(in_memory_limit=in_memory_limit)
         self.provider = S3AssetProvider(self.cache_manager)
         

--- a/autograder/services/assets/s3_provider.py
+++ b/autograder/services/assets/s3_provider.py
@@ -13,7 +13,7 @@ class S3AssetProvider(AssetProvider):
         self.cache_manager = cache_manager
         
         # Environment variables
-        self.bucket_name = os.getenv("CRITERIA_ASSETS_BUCKET_NAME")
+        self.bucket_name = os.getenv("EXTERNAL_ASSETS_BUCKET_NAME")
         self.access_key = os.getenv("AWS_ACCESS_KEY_ID") or os.getenv("AWS_ACCESS_ID")
         self.secret_key = os.getenv("AWS_SECRET_ACCESS_KEY")
         self.region = os.getenv("AWS_REGION", "us-east-1")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       API_PORT: 8000
 
       # S3 Assets Configuration
-      CRITERIA_ASSETS_BUCKET_NAME: autograder-assets
+      EXTERNAL_ASSETS_BUCKET_NAME: autograder-assets
       AWS_ACCESS_ID: test
       AWS_SECRET_ACCESS_KEY: test
       AWS_REGION: us-east-1

--- a/docs/features/setup_config_feature.md
+++ b/docs/features/setup_config_feature.md
@@ -65,7 +65,7 @@ Assets are resolved and injected **before** language-specific setup commands run
 For asset injection to work, the autograder API must be configured with S3 credentials. In a development environment using the provided `docker-compose.yml`, this is handled by the `ministack` service.
 
 Required environment variables:
-- `CRITERIA_ASSETS_BUCKET_NAME`: The name of the S3 bucket.
+- `EXTERNAL_ASSETS_BUCKET_NAME`: The name of the S3 bucket.
 - `S3_ENDPOINT_URL`: The URL of the S3 service (e.g., `http://ministack:4566`).
 - `AWS_ACCESS_ID` & `AWS_SECRET_ACCESS_KEY`: Credentials for the S3 provider.
 


### PR DESCRIPTION


## Context

<!-- Why is this change needed? What problem or issue does it address? -->

## Solution

Replace CRITERIA_ASSETS_* environment variables with EXTERNAL_ASSETS_* across the codebase and docs. Updated .env.example, docker-compose.yml, autograder/services/assets/resolver.py (in-memory cache env var), autograder/services/assets/s3_provider.py (bucket name env var), and docs/features/setup_config_feature.md.
Make sure to update deployment and local environment variables to the new names to avoid configuration breakage.

## Further clarifications

<!-- Any tradeoffs, limitations, follow-up work, or reviewer notes. -->

## Related issues

#301 

## Checklist

- [ ] I linked the related issue(s) and explained the motivation.
- [x] I kept this PR focused and scoped to a single concern.
- [ ] I added or updated tests for changed behavior (or explained why not needed).
- [ ] I ran the relevant tests locally.
- [x] I updated documentation when needed (README/docs/API examples).
- [ ] This PR introduces API contract changes (request/response/endpoint/DTO).
- [ ] If API changed, I documented compatibility or migration notes.
- [x] This PR includes breaking changes.
- [x] If breaking, I clearly described impact and migration steps.
