### PR TITLE
fix: handle None submission_language in PreFlightStep

### DIFF
--- a/autograder/services/pre_flight_service.py
+++ b/autograder/services/pre_flight_service.py
@@ -42,6 +42,10 @@ class PreFlightService:
         """
         Resolve language-specific setup config.
         """
+        if submission_language is None:
+            self.logger.info("No submission language specified, using empty setup config")
+            return LanguageSetupConfig()
+
         lang_key = submission_language.value
         # Using getattr since language keys are fields or extra attributes in SetupConfig
         config = getattr(setup_config, lang_key, None)


### PR DESCRIPTION
## Problem

When using the `webdev` template preset without specifying `submission-language`, the PreFlightStep crashes with:

```
AttributeError: 'NoneType' object has no attribute 'value'
```

## Fix

Added a `None` check in `_resolve_setup_config` — when no language is specified, return an empty `LanguageSetupConfig` instead of attempting to access `.value` on `None`.