### PR TITLE
Add total_score output and GITHUB_OUTPUT write

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,8 @@ inputs:
 outputs:
   result:
     description: "Base64-encoded JSON containing the results of the grading."
+  total_score:
+    description: "Final numeric score (0-100) from the grading pipeline."
 
 # Configures how the action is executed.
 runs:

--- a/github_action/main.py
+++ b/github_action/main.py
@@ -187,6 +187,11 @@ def __retrieve_grading_score(
         raise RuntimeError("Failed to get grading result: autograder returned None")
     logger.info("Final Score for %s: %s", args.student_name, grading_result.final_score)
 
+    github_output = os.getenv("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as fh:
+            fh.write(f"total_score={grading_result.final_score}\n")
+
     return grading_result
 
 


### PR DESCRIPTION
Expose the final numeric score as an action output and populate it at runtime. Adds outputs.total_score to action.yml and appends a total_score=<grading_result.final_score> line to the GITHUB_OUTPUT file (when set) in main.py so downstream workflow steps can consume the 0-100 score.

## Context

<!-- Why is this change needed? What problem or issue does it address? -->

## Solution

<!-- What was changed and how does it solve the problem? -->

## Further clarifications

<!-- Any tradeoffs, limitations, follow-up work, or reviewer notes. -->

## Related issues

<!-- Example: Closes #123 -->

## Checklist

- [ ] I linked the related issue(s) and explained the motivation.
- [ ] I kept this PR focused and scoped to a single concern.
- [ ] I added or updated tests for changed behavior (or explained why not needed).
- [ ] I ran the relevant tests locally.
- [ ] I updated documentation when needed (README/docs/API examples).
- [ ] This PR introduces API contract changes (request/response/endpoint/DTO).
- [ ] If API changed, I documented compatibility or migration notes.
- [ ] This PR includes breaking changes.
- [ ] If breaking, I clearly described impact and migration steps.
