### PR TITLE
Refresh submission on add; update tests

### DIFF
--- a/tests/web/test_database.py
+++ b/tests/web/test_database.py
@@ -54,13 +54,13 @@ async def test_create_grading_config(db_session):
         external_assignment_id="test-assignment-1",
         template_name="webdev",
         criteria_config={"tests": ["test1", "test2"]},
-        language="python",
+        languages=["python"],
     )
     
     assert config.id is not None
     assert config.external_assignment_id == "test-assignment-1"
     assert config.template_name == "webdev"
-    assert config.language == "python"
+    assert config.languages == ["python"]
     assert config.is_active is True
 
 
@@ -74,7 +74,7 @@ async def test_get_config_by_external_id(db_session):
         external_assignment_id="test-assignment-2",
         template_name="api",
         criteria_config={"tests": ["test1"]},
-        language="javascript",
+        languages=["javascript"],
     )
     
     # Retrieve it
@@ -95,13 +95,13 @@ async def test_get_active_configs(db_session):
         external_assignment_id="assignment-1",
         template_name="webdev",
         criteria_config={},
-        language="python",
+        languages=["python"],
     )
     await repo.create(
         external_assignment_id="assignment-2",
         template_name="api",
         criteria_config={},
-        language="java",
+        languages=["java"],
     )
     
     # Get all active
@@ -120,7 +120,7 @@ async def test_create_submission(db_session):
         external_assignment_id="test-assignment-3",
         template_name="webdev",
         criteria_config={},
-        language="python",
+        languages=["python"],
     )
     
     # Create submission
@@ -149,7 +149,7 @@ async def test_get_submissions_by_user(db_session):
         external_assignment_id="test-assignment-4",
         template_name="webdev",
         criteria_config={},
-        language="python",
+        languages=["python"],
     )
     
     # Create multiple submissions for same user
@@ -186,7 +186,7 @@ async def test_update_submission_status(db_session):
         external_assignment_id="test-assignment-5",
         template_name="webdev",
         criteria_config={},
-        language="python",
+        languages=["python"],
     )
     
     submission_repo = SubmissionRepository(db_session)
@@ -217,7 +217,7 @@ async def test_create_submission_result(db_session):
         external_assignment_id="test-assignment-6",
         template_name="webdev",
         criteria_config={},
-        language="python",
+        languages=["python"],
     )
     
     submission_repo = SubmissionRepository(db_session)
@@ -256,7 +256,7 @@ async def test_get_result_by_submission_id(db_session):
         external_assignment_id="test-assignment-7",
         template_name="webdev",
         criteria_config={},
-        language="python",
+        languages=["python"],
     )
     
     submission_repo = SubmissionRepository(db_session)

--- a/web/repositories/submission_repository.py
+++ b/web/repositories/submission_repository.py
@@ -40,6 +40,8 @@ class SubmissionRepository(BaseRepository[Submission]):
         )
 
         self.session.add(db_submission)
+        await self.session.flush()
+        await self.session.refresh(db_submission)
         return db_submission
 
     async def get_by_id_with_result(self, id: int) -> Optional[Submission]:


### PR DESCRIPTION

## Context

The `tests/web/test_database.py` test suite was entirely failing due to schema drift in the database models. Specifically, the `GradingConfiguration` model replaced the string `language` argument with a JSON list `languages` argument, but the test suite was still instantiating configurations using the old keyword `language=...`. This led to a `TypeError` right at the start of the tests.

Additionally, while fixing the tests to reach further down the code, it revealed a latent bug in `SubmissionRepository.create()`. Because this method overrides the base repository creation, it was missing `await self.session.flush()` and `await self.session.refresh(db_submission)` before returning the instance. As a result, newly added submissions did not have their auto-generated `id` populated upon return, causing constraint violations (`IntegrityError: NOT NULL constraint failed: submission_results.submission_id`) in subsequent test steps that expected those persisted values.

## Solution

1. **Updated Tests to Match Schema**: Migrated all occurrences of `language="python"` (and similar) to `languages=["python"]` across all `GradingConfigRepository.create` calls and test assertions in `tests/web/test_database.py`.
2. **Fixed Submission Persistance**: Added `await self.session.flush()` and `await self.session.refresh(db_submission)` right after `self.session.add(db_submission)` in `SubmissionRepository.create` to ensure the entity is correctly synced with the database and auto-generated fields (like `id`) are available before the method returns.

## Further clarifications

No tradeoff implications. This makes the `SubmissionRepository.create` align with the behavior of `BaseRepository.create`, ensuring proper ID propagation needed by downstream workflows such as the submission results pipeline.

## Related issues

#319 

## Checklist

- [x] I linked the related issue(s) and explained the motivation.
- [x] I kept this PR focused and scoped to a single concern.
- [x] I added or updated tests for changed behavior (or explained why not needed).
- [x] I ran the relevant tests locally.
- [ ] I updated documentation when needed (README/docs/API examples).
- [ ] This PR introduces API contract changes (request/response/endpoint/DTO).
- [ ] If API changed, I documented compatibility or migration notes.
- [ ] This PR includes breaking changes.
- [ ] If breaking, I clearly described impact and migration steps.
