### PR TITLE
fix: log preflight issues as warnings

### DIFF
--- a/autograder/services/pre_flight_service.py
+++ b/autograder/services/pre_flight_service.py
@@ -94,7 +94,7 @@ class PreFlightService:  # pylint: disable=too-many-instance-attributes
         for file in self.required_files:
             if file not in submission_files:
                 error_msg = t("preflight.error.required_file_missing", locale=self.locale, file=file)
-                self.logger.error(error_msg)
+                self.logger.warning(error_msg)
                 self.fatal_errors.append(PreflightError(
                     type=PreflightCheckType.FILE_CHECK,
                     message=error_msg,
@@ -142,7 +142,7 @@ class PreFlightService:  # pylint: disable=too-many-instance-attributes
                     command = command_spec
 
                 error_msg = self._format_command_error(command_name, command, response)
-                self.logger.error(error_msg)
+                self.logger.warning(error_msg)
                 self.fatal_errors.append(PreflightError(
                     type=PreflightCheckType.SETUP_COMMAND,
                     message=error_msg,


### PR DESCRIPTION
## Context

The PreFlight step is responsible for validating submissions before grading checking for required files and running setup commands (e.g., compilation). When these checks fail, it is expected behavior: the step exists precisely to catch invalid submissions.

However, failures in `check_required_files` and `check_setup_commands` were being logged at `ERROR` level, causing observability tools (e.g., alerting, dashboards) to treat them as application failures. Logs at `ERROR` should be reserved for unexpected failures in application procedures (e.g., failing to save grading results, failing to fetch a template), not for predictable, student-caused outcomes.

## Solution

Downgraded two `logger.error` calls in `PreFlightService` to `logger.warning`:

- **`check_required_files`**: a missing required file is a known, expected submission validation failure.
- **`check_setup_commands`**: a failed setup command (e.g., compilation error) is a known, expected submission validation failure.

Calls that represent genuine application-level issues were left as `logger.error`:
- Asset injection failure in `PreFlightStep` (infrastructure failure).
- Missing sandbox when setup commands are configured (pipeline misconfiguration).
- `check_setup_commands` called with no sandbox directly via the service (defensive guard, indicates incorrect usage).

## Further clarifications

No behavior changes — only log severity is affected. Observability tools will no longer fire false-positive alerts for routine submission validation failures caught by PreFlight.

## Related issues

Closes #351 

## Checklist

- [x] I linked the related issue(s) and explained the motivation.
- [x] I kept this PR focused and scoped to a single concern.
- [x] I added or updated tests for changed behavior (or explained why not needed).
  - No tests needed: log level is an observability concern, not a behavioral one. Existing tests remain valid.
- [x] I ran the relevant tests locally.
- [ ] I updated documentation when needed (README/docs/API examples). — N/A
- [ ] This PR introduces API contract changes (request/response/endpoint/DTO). — No
- [ ] If API changed, I documented compatibility or migration notes. — N/A
- [ ] This PR includes breaking changes. — No
- [ ] If breaking, I clearly described impact and migration steps. — N/A